### PR TITLE
Potential fix for code scanning alert no. 59: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/homebrew-publish.yml
+++ b/.github/workflows/homebrew-publish.yml
@@ -11,6 +11,9 @@ on:
         description: 'Version to publish (e.g., 0.3.2)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   update-homebrew-tap:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/libre-webui/libre-webui/security/code-scanning/59](https://github.com/libre-webui/libre-webui/security/code-scanning/59)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Because the job does not need to write to the repository via `GITHUB_TOKEN` (pushes are done with `HOMEBREW_TAP_TOKEN`), we can safely set `contents: read` as the default. This aligns with CodeQL’s suggested minimal configuration and preserves existing behavior.

The best minimal fix is to add a root‑level `permissions` block (affecting all jobs) near the top of `.github/workflows/homebrew-publish.yml`, for example just after the `on:` section or before `jobs:`. No changes are needed inside the job steps. Concretely, add:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–13) and the `jobs:` key (line 14). No new methods, imports, or external libraries are required; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
