### PR TITLE
fix: allow HTTP provider gateway endpoints

### DIFF
--- a/backend/src/services/pluginService.ts
+++ b/backend/src/services/pluginService.ts
@@ -677,8 +677,8 @@ export class PluginService {
   }
 
   /**
-   * Validate an endpoint URL for safety (SSRF protection).
-   * Returns the URL string if valid and throws for an unsafe explicit value.
+   * Validate an endpoint override as an absolute HTTP or HTTPS URL.
+   * Returns the URL string if valid and throws for an invalid explicit value.
    */
   private validateEndpointUrl(endpoint: string): string {
     return resolvePluginEndpoint('', endpoint);

--- a/backend/src/utils/pluginValidation.ts
+++ b/backend/src/utils/pluginValidation.ts
@@ -70,36 +70,9 @@ export function validatePluginModel(model: string): void {
   }
 }
 
-function isPrivateIpv4Hostname(hostname: string): boolean {
-  const octets = hostname.split('.');
-  if (octets.length !== 4 || octets.some(octet => !/^\d{1,3}$/.test(octet))) {
-    return false;
-  }
-
-  const values = octets.map(Number);
-  if (values.some(value => value < 0 || value > 255)) {
-    return false;
-  }
-
-  const [first, second] = values;
-  return (
-    first === 10 ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168)
-  );
-}
-
 export function isSafePluginEndpoint(endpoint: string): boolean {
   const url = new URL(endpoint);
-  const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(
-    url.hostname
-  );
-  const isPrivateNetwork = isPrivateIpv4Hostname(url.hostname);
-
-  return (
-    url.protocol === 'https:' ||
-    (url.protocol === 'http:' && (isLocalhost || isPrivateNetwork))
-  );
+  return url.protocol === 'https:' || url.protocol === 'http:';
 }
 
 export function validatePluginEndpointOverride(
@@ -108,7 +81,7 @@ export function validatePluginEndpointOverride(
   try {
     if (!isSafePluginEndpoint(endpoint)) {
       logger.warn(
-        `Rejected insecure endpoint override: ${endpoint} (only HTTPS or localhost/private IPs allowed)`
+        `Rejected unsupported endpoint override: ${endpoint} (only HTTP and HTTPS URLs are allowed)`
       );
       return null;
     }
@@ -128,12 +101,11 @@ export function assertSafePluginEndpoint(
     if (!isSafePluginEndpoint(endpoint)) {
       const url = new URL(endpoint);
       throw new Error(
-        `Insecure endpoint protocol: ${url.protocol}. Only HTTPS is allowed for remote endpoints. ` +
-          `(HTTP is permitted for localhost and private network IPs)`
+        `Unsupported endpoint protocol: ${url.protocol}. Only HTTP and HTTPS URLs are allowed.`
       );
     }
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('Insecure')) {
+    if (error instanceof Error && error.message.startsWith('Unsupported')) {
       throw error;
     }
 
@@ -153,8 +125,7 @@ export function resolvePluginEndpoint(
   const validatedOverride = validatePluginEndpointOverride(normalizedOverride);
   if (!validatedOverride) {
     throw new Error(
-      'Invalid or unsafe plugin endpoint override. Use HTTPS for remote endpoints, ' +
-        'or HTTP for localhost and private IPv4 addresses.'
+      'Invalid plugin endpoint override. Use an absolute HTTP or HTTPS URL.'
     );
   }
 

--- a/backend/src/utils/pluginVariableValidation.ts
+++ b/backend/src/utils/pluginVariableValidation.ts
@@ -159,9 +159,7 @@ export function validatePluginVariables(
       if (!validatedUrl) {
         return {
           success: false,
-          error:
-            `Variable "${key}" must use HTTPS for remote URLs, or HTTP ` +
-            'for localhost and private IPv4 addresses',
+          error: `Variable "${key}" must use an absolute HTTP or HTTPS URL`,
         };
       }
       if (key.toLowerCase().endsWith('base_url')) {

--- a/docs/06-TROUBLESHOOTING.md
+++ b/docs/06-TROUBLESHOOTING.md
@@ -170,11 +170,13 @@ OpenAI Responses, Anthropic, or Gemini-compatible wire format. If the provider
 uses a proprietary payload, streaming event, tool-call, or response format, it
 needs a backend adapter; changing only the endpoint cannot translate it.
 
-Remote provider URLs must use HTTPS. HTTP is accepted only for localhost and
-private-network addresses. Base URLs cannot contain query strings or fragments,
-and relative API paths cannot contain literal or repeatedly encoded traversal
-segments, query strings, or fragments. Excessive encoding is rejected when it
-does not stabilize within the validation bound.
+Provider URLs may use HTTP or HTTPS. HTTP sends credentials and provider traffic
+without transport encryption, so reserve it for a self-hosted gateway on a
+trusted network and prefer HTTPS whenever TLS is available. Base URLs cannot
+contain query strings or fragments, and relative API paths cannot contain
+literal or repeatedly encoded traversal segments, query strings, or fragments.
+Excessive encoding is rejected when it does not stabilize within the validation
+bound.
 
 Model refresh replaces known operation suffixes, including `/responses`, with
 `/models`. Activation, explicit refresh, and saved connection overrides use the
@@ -195,11 +197,13 @@ after finishing the provider settings update. Work intentionally stops before
 its next provider request so prior tool state cannot be replayed to a different
 mode, endpoint, or API-key authentication boundary.
 
-HTTP is accepted only for exact loopback hosts or private IPv4 literals.
-Hostnames such as `host.docker.internal` and `10.example.com` are not private
-IP literals and therefore require HTTPS. Requests originate from the backend,
-so `localhost` refers to the Libre WebUI container when the backend runs in a
-container, not automatically to the host machine.
+Requests originate from the backend, so `localhost` refers to the Libre WebUI
+container when the backend runs in a container, not automatically to the host
+machine. For a Compose or Kubernetes deployment, use the gateway's service DNS
+name, for example `http://ai-gateway:8080/v1`. Use
+`http://host.docker.internal:8080/v1` only when the container runtime exposes
+that host alias. HTTP traffic is plaintext even when the name resolves
+privately.
 
 Image model availability, endpoint overrides, and API keys are resolved for
 the current user too. If an image request appears to use another account's
@@ -215,9 +219,9 @@ The following security and ownership rules also apply:
   endpoint URL, including the operation path (for example,
   `https://provider.example/v1/chat/completions`). Enter an API root only in
   `base_url`, paired with `api_mode` and an optional `api_path`.
-- Remote endpoints require HTTPS. HTTP is accepted only for exact loopback
-  hosts or private IPv4 literals. Hostnames such as `host.docker.internal` and
-  `10.example.com` are not private IP literals and therefore require HTTPS.
+- Absolute HTTP and HTTPS endpoint URLs are accepted. Use HTTP only for a
+  self-hosted gateway on a trusted network because API keys, prompts, and
+  responses are otherwise sent without transport encryption.
 - An empty override uses the endpoint bundled in the plugin definition. An
   explicit malformed or unsafe override is rejected; Libre WebUI does not
   silently send that request to the bundled provider endpoint.

--- a/docs/08-PLUGIN_ARCHITECTURE.md
+++ b/docs/08-PLUGIN_ARCHITECTURE.md
@@ -247,12 +247,13 @@ follow HTTP redirects. Configure the final Chat, Work, model-list, image,
 embedding, or TTS endpoint directly; this prevents credentials from being
 forwarded from a validated URL to an unvalidated redirect destination.
 
-Remote endpoints must use HTTPS. Plain HTTP is accepted only for exact loopback
-hosts (`localhost`, `127.0.0.1`, or `[::1]`) and private IPv4 literals in the
-`10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16` ranges. Requests originate
-from the backend, so `localhost` identifies the Libre WebUI container when the
-backend runs in a container. Plugin capability routes, including image
-generation, resolve endpoint variables and credentials for the requesting
+Provider endpoints may use HTTP or HTTPS. HTTP sends API keys, prompts, tool
+results, and generated content without transport encryption, so use it only for
+a self-hosted gateway on a network you trust; prefer HTTPS whenever the gateway
+supports TLS. Requests originate from the backend. In container deployments,
+that means a service URL such as `http://ai-gateway:8080/v1`, while `localhost`
+identifies the Libre WebUI container itself. Plugin capability routes, including
+image generation, resolve endpoint variables and credentials for the requesting
 user. Single-user mode uses the `default` user.
 
 ### Capability-specific endpoints
@@ -279,13 +280,12 @@ path. For example, an OpenAI-compatible chat plugin normally uses a URL such as
 variable `api_url`; Libre WebUI accepts that alias, but a non-empty `endpoint`
 always takes precedence when both are present.
 
-Remote endpoints must use HTTPS. Plain HTTP is accepted only for exact loopback
-hosts (`localhost`, `127.0.0.1`, or `[::1]`) and private IPv4 literals in the
-`10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16` ranges. A hostname that
-merely looks private, such as `10.example.com`, is still a remote hostname and
-requires HTTPS. Other protocols are rejected. Leaving the override empty uses
-the full endpoint from the plugin definition; an explicit invalid or unsafe
-override is rejected instead of silently routing to that default.
+Absolute HTTP and HTTPS endpoint URLs are accepted; other protocols are
+rejected. HTTP is intended for self-hosted gateways on trusted networks because
+it sends credentials and request content without transport encryption. Prefer
+HTTPS for any route that leaves a private deployment boundary. Leaving the
+override empty uses the full endpoint from the plugin definition; an explicit
+invalid override is rejected instead of silently routing to that default.
 
 Provider requests do not follow redirects. Configure the final validated
 operation URL directly; a redirect response is reported as a provider error
@@ -293,7 +293,9 @@ instead of forwarding credentials or request content to another hop.
 
 Remember that requests originate from the Libre WebUI backend. In a container,
 `localhost` identifies the container itself, not automatically the container
-host or another service.
+host or another service. Use the gateway's container service name, or a
+host-reachable name such as `host.docker.internal` where the container runtime
+provides it.
 
 ### Model Discovery
 

--- a/docs/32-KIMI_CODE.md
+++ b/docs/32-KIMI_CODE.md
@@ -52,7 +52,9 @@ https://api.kimi.com/coding/v1/chat/completions
 ```
 
 The endpoint can be overridden in the plugin variables for compatible gateways
-or proxies. Remote overrides must use HTTPS.
+or proxies. HTTP overrides are supported for self-hosted gateways, but send the
+API key and request content without transport encryption. Use HTTP only on a
+trusted network and prefer HTTPS whenever the gateway supports TLS.
 
 ## Privacy and Usage
 

--- a/frontend/e2e/settings.spec.ts
+++ b/frontend/e2e/settings.spec.ts
@@ -261,6 +261,30 @@ test('admin provider settings are collapsed, inherited, sparse, and retryable', 
     'Use provider default (custom-model)'
   );
 
+  const httpWarning = page.getByText(
+    'HTTP does not encrypt credentials or traffic. Use it only on a trusted network.',
+    { exact: true }
+  );
+  await expect(httpWarning).toHaveCount(0);
+  await endpointInput.fill('ftp://ai-gateway:8080/v1/chat/completions');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect(
+    page.getByText('API endpoints must use HTTP or HTTPS.', { exact: true })
+  ).toBeVisible();
+  expect(mockApi.pluginVariableUpdateRequests).toHaveLength(0);
+
+  await endpointInput.fill('http://ai-gateway:8080/v1/chat/completions');
+  await expect(httpWarning).toBeVisible();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await expect.poll(() => mockApi.pluginVariableUpdateRequests.length).toBe(1);
+  expect(mockApi.pluginVariableUpdateRequests[0]).toEqual({
+    pluginId: 'custom-provider',
+    variables: {
+      endpoint: 'http://ai-gateway:8080/v1/chat/completions',
+    },
+    unset: [],
+  });
+
   const providerAdvancedDisclosure = page.getByRole('button', {
     name: /Advanced parameters/,
   });
@@ -286,12 +310,14 @@ test('admin provider settings are collapsed, inherited, sparse, and retryable', 
   await apiModeInput.selectOption('chat_completions');
   await apiModeInput.selectOption('');
   await customImageEndpointInput.fill(
-    'https://temporary.example/v1/images/generations'
+    'http://image-gateway:8080/v1/images/generations'
   );
+  await expect(httpWarning).toBeVisible();
   await customImageEndpointInput.fill('');
+  await expect(httpWarning).toHaveCount(0);
   await page.getByRole('button', { name: 'Save', exact: true }).click();
-  await expect.poll(() => mockApi.pluginVariableUpdateRequests.length).toBe(1);
-  expect(mockApi.pluginVariableUpdateRequests[0]).toEqual({
+  await expect.poll(() => mockApi.pluginVariableUpdateRequests.length).toBe(2);
+  expect(mockApi.pluginVariableUpdateRequests[1]).toEqual({
     pluginId: 'custom-provider',
     variables: {},
     unset: ['endpoint'],
@@ -304,8 +330,8 @@ test('admin provider settings are collapsed, inherited, sparse, and retryable', 
   await page.getByRole('button', { name: 'Show Secret Header value' }).click();
   await expect(secretInput).toHaveAttribute('type', 'text');
   await page.getByRole('button', { name: 'Save', exact: true }).click();
-  await expect.poll(() => mockApi.pluginVariableUpdateRequests.length).toBe(2);
-  expect(mockApi.pluginVariableUpdateRequests[1]).toEqual({
+  await expect.poll(() => mockApi.pluginVariableUpdateRequests.length).toBe(3);
+  expect(mockApi.pluginVariableUpdateRequests[2]).toEqual({
     pluginId: 'custom-provider',
     variables: { secret_header: 'temporary-plaintext-secret' },
     unset: [],

--- a/frontend/src/components/PluginManager.tsx
+++ b/frontend/src/components/PluginManager.tsx
@@ -31,10 +31,18 @@ import {
   X,
   Zap,
 } from '@/components/icons';
-import { ChevronDown, RotateCcw, Save, Eye, EyeOff } from 'lucide-react';
+import {
+  AlertTriangle,
+  ChevronDown,
+  RotateCcw,
+  Save,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
 import { cn } from '@/utils';
 import {
   getPluginEndpointValidationError,
+  isPluginHttpEndpoint,
   isPluginUrlVariable,
   isValidPluginApiPath,
 } from '@/utils/pluginEndpoint';
@@ -168,7 +176,7 @@ export const PluginVariablesEditor: React.FC<{
         } else if (endpointError === 'insecure-url') {
           errors[def.name] = t(
             'pluginManager.variables.insecureUrl',
-            'Remote API endpoints must use HTTPS. HTTP is allowed only for localhost and private IPv4 addresses.'
+            'API endpoints must use HTTP or HTTPS.'
           );
         } else if (endpointError === 'query-or-fragment') {
           errors[def.name] = t(
@@ -352,7 +360,23 @@ export const PluginVariablesEditor: React.FC<{
       controlId,
       descriptionId: `${controlId}-description`,
       errorId: `${controlId}-error`,
+      warningId: `${controlId}-http-warning`,
     };
+  };
+
+  const hasHttpEndpointWarning = (def: PluginVariableDefinition): boolean => {
+    if (!isPluginUrlVariable(def.name)) return false;
+
+    const localValue = localValues[def.name];
+    const inheritedValue = getInheritedPluginVariableValue(def, plugin);
+    const endpointValue =
+      typeof localValue === 'string' && localValue.trim()
+        ? localValue
+        : inheritedValue;
+
+    return (
+      typeof endpointValue === 'string' && isPluginHttpEndpoint(endpointValue)
+    );
   };
 
   const renderField = (def: PluginVariableDefinition) => {
@@ -360,12 +384,14 @@ export const PluginVariablesEditor: React.FC<{
     const isSensitive = def.sensitive ?? false;
     const isRevealed = revealedFields.has(def.name);
     const storedVar = storedVars[def.name] as PluginVariableValue | undefined;
-    const { controlId, descriptionId, errorId } = getFieldIds(def);
+    const { controlId, descriptionId, errorId, warningId } = getFieldIds(def);
     const hasError = Boolean(fieldErrors[def.name]);
+    const hasHttpWarning = hasHttpEndpointWarning(def);
     const hasEndpointHelp = def.name === 'endpoint' || def.name === 'api_url';
     const describedBy =
       [
         def.description || hasEndpointHelp ? descriptionId : undefined,
+        hasHttpWarning ? warningId : undefined,
         hasError ? errorId : undefined,
       ]
         .filter(Boolean)
@@ -513,8 +539,9 @@ export const PluginVariablesEditor: React.FC<{
   };
 
   const renderDefinition = (def: PluginVariableDefinition) => {
-    const { controlId, descriptionId, errorId } = getFieldIds(def);
+    const { controlId, descriptionId, errorId, warningId } = getFieldIds(def);
     const hasEndpointHelp = def.name === 'endpoint' || def.name === 'api_url';
+    const hasHttpWarning = hasHttpEndpointWarning(def);
 
     return (
       <div key={def.name}>
@@ -549,6 +576,24 @@ export const PluginVariablesEditor: React.FC<{
           </p>
         )}
         {renderField(def)}
+        {hasHttpWarning && (
+          <p
+            id={warningId}
+            role='status'
+            className='mt-1 flex items-start gap-1 text-xs text-amber-700 dark:text-amber-400'
+          >
+            <AlertTriangle
+              aria-hidden='true'
+              className='mt-0.5 h-3.5 w-3.5 shrink-0'
+            />
+            <span>
+              {t(
+                'pluginManager.variables.httpWarning',
+                'HTTP does not encrypt credentials or traffic. Use it only on a trusted network.'
+              )}
+            </span>
+          </p>
+        )}
         {fieldErrors[def.name] && (
           <p id={errorId} role='alert' className='text-xs text-red-500 mt-1'>
             {fieldErrors[def.name]}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1310,7 +1310,8 @@
       "fullApiEndpoint": "Full API endpoint URL",
       "endpointHelp": "Enter the complete request URL, including its operation path (for example, /v1/chat/completions), not only the provider base URL.",
       "invalidUrl": "Enter a valid full API endpoint URL, for example https://provider.example/v1/chat/completions",
-      "insecureUrl": "Remote API endpoints must use HTTPS. HTTP is allowed only for localhost and private IPv4 addresses.",
+      "insecureUrl": "API endpoints must use HTTP or HTTPS.",
+      "httpWarning": "HTTP does not encrypt credentials or traffic. Use it only on a trusted network.",
       "invalidBaseUrl": "Base URLs cannot contain a query string or fragment.",
       "invalidApiPath": "Must start with / and contain no URL, query, fragment, or .. segment",
       "tooLong": "Value is too long"

--- a/frontend/src/utils/pluginEndpoint.test.ts
+++ b/frontend/src/utils/pluginEndpoint.test.ts
@@ -21,6 +21,7 @@ import {
   getPluginEndpointValidationError,
   hasPluginModelDiscoveryVariable,
   isPluginConnectionEndpointVariable,
+  isPluginHttpEndpoint,
   isPluginUrlVariable,
   isValidPluginApiPath,
 } from './pluginEndpoint';
@@ -73,15 +74,14 @@ test('accepts full HTTPS API endpoint URLs', () => {
   );
 });
 
-test('accepts HTTP only for exact loopback hosts and private IPv4 literals', () => {
+test('accepts absolute HTTP endpoint URLs for self-hosted gateways', () => {
   const allowed = [
     'http://localhost:8080/v1/chat/completions',
     'http://127.0.0.1:8080/v1/chat/completions',
     'http://[::1]:8080/v1/chat/completions',
     'http://10.0.0.5:8080/v1/chat/completions',
-    'http://172.16.0.5:8080/v1/chat/completions',
-    'http://172.31.255.254:8080/v1/chat/completions',
-    'http://192.168.1.5:8080/v1/chat/completions',
+    'http://ai-gateway:8080/v1/chat/completions',
+    'http://gateway.internal.example:8080/v1/chat/completions',
   ];
 
   for (const endpoint of allowed) {
@@ -93,22 +93,16 @@ test('accepts HTTP only for exact loopback hosts and private IPv4 literals', () 
   }
 });
 
-test('rejects malformed, relative, and remote HTTP endpoint URLs', () => {
+test('rejects malformed and relative endpoint URLs', () => {
   assert.equal(
     getPluginEndpointValidationError('/v1/chat/completions'),
     'invalid-url'
   );
   assert.equal(getPluginEndpointValidationError('not a URL'), 'invalid-url');
-  assert.equal(
-    getPluginEndpointValidationError(
-      'http://provider.example/v1/chat/completions'
-    ),
-    'insecure-url'
-  );
 });
 
-test('does not mistake private-looking hostnames or adjacent ranges for private IPv4 literals', () => {
-  const rejected = [
+test('accepts HTTP hostnames and IPv4 addresses regardless of address range', () => {
+  const allowed = [
     'http://10.example.com/v1/chat/completions',
     'http://localhost.example.com/v1/chat/completions',
     'http://172.15.0.1/v1/chat/completions',
@@ -116,16 +110,16 @@ test('does not mistake private-looking hostnames or adjacent ranges for private 
     'http://192.169.0.1/v1/chat/completions',
   ];
 
-  for (const endpoint of rejected) {
+  for (const endpoint of allowed) {
     assert.equal(
       getPluginEndpointValidationError(endpoint),
-      'insecure-url',
-      `${endpoint} should be rejected`
+      null,
+      `${endpoint} should be allowed`
     );
   }
 });
 
-test('rejects non-HTTP protocols even for local endpoints', () => {
+test('rejects protocols other than HTTP and HTTPS', () => {
   assert.equal(
     getPluginEndpointValidationError('ftp://localhost/v1/chat/completions'),
     'insecure-url'
@@ -134,6 +128,18 @@ test('rejects non-HTTP protocols even for local endpoints', () => {
     getPluginEndpointValidationError('file:///v1/chat/completions'),
     'insecure-url'
   );
+});
+
+test('identifies HTTP endpoints for plaintext transport warnings', () => {
+  assert.equal(
+    isPluginHttpEndpoint('  http://ai-gateway:8080/v1/responses  '),
+    true
+  );
+  assert.equal(
+    isPluginHttpEndpoint('https://provider.example/v1/responses'),
+    false
+  );
+  assert.equal(isPluginHttpEndpoint('/v1/responses'), false);
 });
 
 test('rejects query strings and fragments on provider base URLs', () => {

--- a/frontend/src/utils/pluginEndpoint.ts
+++ b/frontend/src/utils/pluginEndpoint.ts
@@ -18,7 +18,6 @@
 export type PluginEndpointValidationError =
   'invalid-url' | 'insecure-url' | 'query-or-fragment';
 
-const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
 const MAX_API_PATH_DECODE_PASSES = 8;
 const PLUGIN_MODEL_DISCOVERY_VARIABLES = new Set([
   'endpoint',
@@ -39,32 +38,9 @@ export function hasPluginModelDiscoveryVariable(
   return Object.keys(values).some(isPluginConnectionEndpointVariable);
 }
 
-function isPrivateIpv4Literal(hostname: string): boolean {
-  const octets = hostname.split('.');
-  if (octets.length !== 4 || octets.some(octet => !/^\d{1,3}$/.test(octet))) {
-    return false;
-  }
-
-  const [first, second, third, fourth] = octets.map(Number);
-  if (
-    [first, second, third, fourth].some(
-      octet => !Number.isInteger(octet) || octet < 0 || octet > 255
-    )
-  ) {
-    return false;
-  }
-
-  return (
-    first === 10 ||
-    (first === 172 && second >= 16 && second <= 31) ||
-    (first === 192 && second === 168)
-  );
-}
-
 /**
  * Match the backend's endpoint override policy before variables are saved.
- * Remote endpoints require HTTPS. Plain HTTP is limited to exact loopback
- * hosts and private IPv4 literals.
+ * Endpoint overrides must be absolute HTTP or HTTPS URLs.
  */
 export function getPluginEndpointValidationError(
   endpoint: string,
@@ -83,11 +59,7 @@ export function getPluginEndpointValidationError(
     return 'invalid-url';
   }
 
-  const safeProtocol =
-    url.protocol === 'https:' ||
-    (url.protocol === 'http:' &&
-      (LOOPBACK_HOSTS.has(url.hostname) || isPrivateIpv4Literal(url.hostname)));
-  if (!safeProtocol) {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     return 'insecure-url';
   }
 
@@ -99,6 +71,14 @@ export function getPluginEndpointValidationError(
   }
 
   return null;
+}
+
+export function isPluginHttpEndpoint(endpoint: string): boolean {
+  try {
+    return new URL(endpoint.trim()).protocol === 'http:';
+  } catch {
+    return false;
+  }
 }
 
 export function isPluginUrlVariable(name: string): boolean {

--- a/scripts/test-chat-context.mjs
+++ b/scripts/test-chat-context.mjs
@@ -1169,7 +1169,7 @@ test('plugin model routing requires an active plugin and the current user creden
   }
 });
 
-test('plugin validation rejects unsafe models and remote HTTP endpoints', () => {
+test('plugin validation rejects unsafe models and non-HTTP provider endpoints', () => {
   assert.doesNotThrow(() =>
     pluginValidation.validatePluginModel('kimi-k2.7-code:cloud')
   );
@@ -1180,9 +1180,14 @@ test('plugin validation rejects unsafe models and remote HTTP endpoints', () => 
     () => pluginValidation.validatePluginModel('../secret'),
     /invalid patterns/
   );
+  assert.doesNotThrow(() =>
+    pluginValidation.assertSafePluginEndpoint(
+      'http://ai-gateway:8080/v1/chat/completions'
+    )
+  );
   assert.throws(
-    () => pluginValidation.assertSafePluginEndpoint('http://example.com/v1'),
-    /Insecure endpoint protocol/
+    () => pluginValidation.assertSafePluginEndpoint('ftp://example.com/v1'),
+    /Unsupported endpoint protocol/
   );
   assert.doesNotThrow(() =>
     pluginValidation.assertSafePluginEndpoint(

--- a/scripts/test-plugin-endpoint-routing.mjs
+++ b/scripts/test-plugin-endpoint-routing.mjs
@@ -1197,29 +1197,31 @@ test('custom endpoint resolution is full-URL based and fails closed', () => {
     ),
     'https://catalog.example.test/custom/models?preview=true'
   );
-  assert.throws(
-    () =>
-      pluginValidation.resolvePluginModelsEndpoint(
-        customEndpoint,
-        'http://catalog.example.test/models'
-      ),
-    /Invalid or unsafe plugin endpoint override/
+  assert.equal(
+    pluginValidation.resolvePluginModelsEndpoint(
+      customEndpoint,
+      'http://catalog.example.test/models'
+    ),
+    'http://catalog.example.test/models'
   );
 
   for (const unsafeEndpoint of [
-    'http://api.openai.com/v1/chat/completions',
     'ftp://localhost/v1/chat/completions',
-    'http://10.example.test/v1/chat/completions',
+    'file:///v1/chat/completions',
     'not a URL',
   ]) {
     assert.throws(
       () =>
         pluginValidation.resolvePluginEndpoint(bundledEndpoint, unsafeEndpoint),
-      /Invalid or unsafe plugin endpoint override/
+      /Invalid plugin endpoint override/
     );
   }
 
-  for (const localEndpoint of [
+  for (const httpEndpoint of [
+    'http://ai-gateway:8080/v1/chat/completions',
+    'http://host.docker.internal:8080/v1/chat/completions',
+    'http://gateway.internal:8080/v1/chat/completions',
+    'http://api.openai.com/v1/chat/completions',
     'http://localhost:8080/v1/chat/completions',
     'http://127.0.0.1:8080/v1/chat/completions',
     'http://[::1]:8080/v1/chat/completions',
@@ -1228,8 +1230,8 @@ test('custom endpoint resolution is full-URL based and fails closed', () => {
     'http://192.168.0.8:8080/v1/chat/completions',
   ]) {
     assert.equal(
-      pluginValidation.resolvePluginEndpoint(bundledEndpoint, localEndpoint),
-      localEndpoint
+      pluginValidation.resolvePluginEndpoint(bundledEndpoint, httpEndpoint),
+      httpEndpoint
     );
   }
 });
@@ -1237,7 +1239,7 @@ test('custom endpoint resolution is full-URL based and fails closed', () => {
 test('Chat and Work requests use a valid custom endpoint instead of the bundled endpoint', async () => {
   const plugin = createPlugin();
   const customEndpoint =
-    'https://gateway.example.test/openai/v1/chat/completions';
+    'http://ai-gateway:8080/openai/v1/chat/completions';
   const requests = [];
 
   await withPatchedProperties(
@@ -1358,7 +1360,7 @@ test('Chat and Work streaming fail closed on redirects', async () => {
       key_env: 'STREAM_REDIRECT_API_KEY',
     },
   });
-  const endpoint = 'https://gateway.example.test/openai/v1/chat/completions';
+  const endpoint = 'http://ai-gateway:8080/openai/v1/chat/completions';
   const requests = [];
   const streamResponse = () =>
     new Response(
@@ -2451,7 +2453,7 @@ test('environment fallback fails closed when bundled and writable directories al
   }
 });
 
-test('connection endpoint aliases reject unsafe URLs and preserve blank fallback', () => {
+test('connection endpoint aliases accept HTTP URLs and preserve blank fallback', () => {
   const definitions = ['endpoint', 'api_url', 'models_endpoint'].map(name => ({
     name,
     type: 'string',
@@ -2475,12 +2477,22 @@ test('connection endpoint aliases reject unsafe URLs and preserve blank fallback
         },
       }
     );
+    assert.deepEqual(
+      pluginVariableValidation.validatePluginVariables(definitions, {
+        [name]: '  http://ai-gateway:8080/v1/chat/completions  ',
+      }),
+      {
+        success: true,
+        variables: {
+          [name]: 'http://ai-gateway:8080/v1/chat/completions',
+        },
+      }
+    );
   }
 
   for (const endpoint of [
-    'http://api.openai.com/v1/chat/completions',
     'ftp://localhost/v1/chat/completions',
-    'http://10.example.test/v1/chat/completions',
+    'file:///v1/chat/completions',
   ]) {
     for (const name of ['endpoint', 'api_url', 'models_endpoint']) {
       const result = pluginVariableValidation.validatePluginVariables(
@@ -2488,7 +2500,7 @@ test('connection endpoint aliases reject unsafe URLs and preserve blank fallback
         { [name]: endpoint }
       );
       assert.equal(result.success, false);
-      assert.match(result.error, /must use HTTPS for remote URLs/);
+      assert.match(result.error, /absolute HTTP or HTTPS URL/);
     }
   }
 
@@ -2510,9 +2522,9 @@ test('model discovery uses the user endpoint and credentials without default fal
     },
   });
   const customEndpoint =
-    'https://gateway.example.test/openai/v1/chat/completions';
+    'http://ai-gateway:8080/openai/v1/chat/completions';
   const customModelsEndpoint =
-    'https://catalog.example.test/provider/models?channel=preview';
+    'http://model-catalog:8080/provider/models?channel=preview';
   const requests = [];
   let currentEndpoint = customEndpoint;
   let currentModelsEndpoint = customModelsEndpoint;
@@ -2562,10 +2574,10 @@ test('model discovery uses the user endpoint and credentials without default fal
           );
           assert.equal(credentialLookups, 1);
 
-          currentModelsEndpoint = 'http://api.openai.com/v1/models';
+          currentModelsEndpoint = 'ftp://api.openai.com/v1/models';
           await assert.rejects(
             pluginService.discoverModels(plugin.id, 'user-42'),
-            /Invalid or unsafe plugin endpoint override/
+            /Invalid plugin endpoint override/
           );
           assert.equal(
             requests.length,
@@ -2835,12 +2847,12 @@ test('discovered models persist per user without mutating the shared plugin mani
   );
 });
 
-test('embedding and TTS requests reject redirects before a credential-bearing hop', async () => {
+test('embedding and TTS HTTP requests reject redirects before a credential-bearing hop', async () => {
   const plugin = createPlugin({ id: 'capability-redirect-provider' });
   plugin.capabilities.embedding.endpoint =
-    'https://gateway.example.test/v1/embeddings';
+    'http://ai-gateway:8080/v1/embeddings';
   plugin.capabilities.tts.endpoint =
-    'https://gateway.example.test/v1/audio/speech';
+    'http://ai-gateway:8080/v1/audio/speech';
   const requests = [];
 
   await withPatchedProperties(
@@ -2898,7 +2910,7 @@ test('embedding and TTS requests reject redirects before a credential-bearing ho
 
 test('Chat, Work, embedding, TTS, and image overrides fail before network access', async () => {
   const plugin = createPlugin();
-  const unsafeEndpoint = 'http://api.openai.com/v1/chat/completions';
+  const unsafeEndpoint = 'ftp://api.openai.com/v1/chat/completions';
   let networkRequests = 0;
   let credentialLookups = 0;
 
@@ -2936,7 +2948,7 @@ test('Chat, Work, embedding, TTS, and image overrides fail before network access
               {},
               'user-42'
             ),
-            /Invalid or unsafe plugin endpoint override/
+            /Invalid plugin endpoint override/
           );
           assert.equal(
             credentialLookups,
@@ -2950,14 +2962,14 @@ test('Chat, Work, embedding, TTS, and image overrides fail before network access
               plugin.id,
               'user-42'
             ),
-            /Invalid or unsafe plugin endpoint override/
+            /Invalid plugin endpoint override/
           );
           await assert.rejects(
             pluginService.executeTTSRequest('tts-model', 'Hello', {
               pluginId: plugin.id,
               userId: 'user-42',
             }),
-            /Invalid or unsafe plugin endpoint override/
+            /Invalid plugin endpoint override/
           );
           await assert.rejects(
             pluginService.executeImageGenRequest(
@@ -2968,7 +2980,7 @@ test('Chat, Work, embedding, TTS, and image overrides fail before network access
                 userId: 'user-42',
               }
             ),
-            /Invalid or unsafe plugin endpoint override/
+            /Invalid plugin endpoint override/
           );
         }
       )
@@ -3010,7 +3022,7 @@ test('Chat, Work, embedding, TTS, and image overrides fail before network access
       { providerType: 'plugin', providerId: plugin.id },
       'user-42'
     ),
-    /Invalid or unsafe plugin endpoint override/
+    /Invalid plugin endpoint override/
   );
   assert.equal(networkRequests, 0);
 });
@@ -3042,7 +3054,7 @@ test('image discovery and requests use the current user endpoint and credentials
       userContexts.push({ operation: 'variables', userId });
       return {
         image_endpoint:
-          'https://image-user.example.test/v1/images/generations?custom=true',
+          'http://image-gateway:8080/v1/images/generations?custom=true',
       };
     },
     validateEndpointUrl: endpoint =>
@@ -3089,7 +3101,7 @@ test('image discovery and requests use the current user endpoint and credentials
 
   assert.equal(
     request.endpoint,
-    'https://image-user.example.test/v1/images/generations?custom=true'
+    'http://image-gateway:8080/v1/images/generations?custom=true'
   );
   assert.equal(request.config.headers.Authorization, 'Bearer key-image-user');
   assert.equal(request.config.maxRedirects, 0);

--- a/scripts/test-provider-api-modes.mjs
+++ b/scripts/test-provider-api-modes.mjs
@@ -774,19 +774,21 @@ test('provider API configuration resolves modes, base URLs, paths, and model dis
     ),
     'https://gateway.example/v2/models'
   );
-  assert.throws(
-    () =>
-      pluginValidation.resolvePluginApiConfig(plugin, {
-        base_url: 'http://public.example/v1',
-      }),
-    /Insecure endpoint protocol/
+  assert.deepEqual(
+    pluginValidation.resolvePluginApiConfig(plugin, {
+      base_url: 'http://gateway.internal:8080/v1',
+    }),
+    {
+      apiMode: 'chat_completions',
+      endpoint: 'http://gateway.internal:8080/v1/chat/completions',
+    }
   );
   for (const endpoint of [
     'http://10.example.com/v1',
     'http://172.16.example.com/v1',
     'http://192.168.example.com/v1',
   ]) {
-    assert.equal(pluginValidation.isSafePluginEndpoint(endpoint), false);
+    assert.equal(pluginValidation.isSafePluginEndpoint(endpoint), true);
   }
   for (const endpoint of [
     'http://10.0.0.8/v1',
@@ -887,7 +889,7 @@ test('Responses replay and Work routing change when provider credentials rotate'
   assert.notEqual(oldRoutingFingerprint, newRoutingFingerprint);
 });
 
-test('model discovery rejects an unsafe derived URL before reading credentials', async () => {
+test('model discovery rejects an unsupported derived URL before reading credentials', async () => {
   const service = pluginServiceModule.default;
   const originalGetPlugin = service.getPlugin;
   const originalGetPluginVariables = service.getPluginVariables;
@@ -898,10 +900,10 @@ test('model discovery rejects an unsafe derived URL before reading credentials',
 
   try {
     service.getPlugin = () => ({
-      id: 'unsafe-provider',
-      name: 'Unsafe provider',
+      id: 'unsupported-provider',
+      name: 'Unsupported provider',
       type: 'completion',
-      endpoint: 'http://public.example/v1/chat/completions',
+      endpoint: 'ftp://public.example/v1/chat/completions',
       auth: {
         header: 'Authorization',
         prefix: 'Bearer ',
@@ -920,8 +922,8 @@ test('model discovery rejects an unsafe derived URL before reading credentials',
     };
 
     await assert.rejects(
-      service.discoverModels('unsafe-provider', 'unsafe-user'),
-      /Insecure endpoint protocol/
+      service.discoverModels('unsupported-provider', 'unsafe-user'),
+      /Unsupported endpoint protocol/
     );
     assert.equal(credentialsRead, false);
     assert.equal(requestMade, false);
@@ -2311,12 +2313,18 @@ test('plugin routes and activation keep model discovery scoped to the authentica
       200
     );
 
-    const insecureSave = await invokeRoute('/:id/variables', 'PUT', {
+    const httpSave = await invokeRoute('/:id/variables', 'PUT', {
       params: { id: 'openai' },
       body: { variables: { base_url: 'http://public.example/v1' } },
     });
-    assert.equal(insecureSave.statusCode, 400);
-    assert.match(insecureSave.payload.error, /HTTPS/);
+    assert.equal(httpSave.statusCode, 200);
+
+    const unsupportedSchemeSave = await invokeRoute('/:id/variables', 'PUT', {
+      params: { id: 'openai' },
+      body: { variables: { base_url: 'ftp://public.example/v1' } },
+    });
+    assert.equal(unsupportedSchemeSave.statusCode, 400);
+    assert.match(unsupportedSchemeSave.payload.error, /HTTP or HTTPS/);
 
     const traversalSave = await invokeRoute('/:id/variables', 'PUT', {
       params: { id: 'openai' },
@@ -2367,6 +2375,22 @@ test('plugin routes and activation keep model discovery scoped to the authentica
       {
         operation: 'activate',
         pluginId: 'openai',
+      },
+      {
+        operation: 'discover',
+        pluginId: 'openai',
+        userId: 'route-user',
+      },
+      {
+        operation: 'save',
+        pluginId: 'openai',
+        userId: 'route-user',
+        variables: { base_url: 'http://public.example/v1' },
+      },
+      {
+        operation: 'clear',
+        pluginId: 'openai',
+        userId: 'route-user',
       },
       {
         operation: 'discover',


### PR DESCRIPTION
## Summary

- accept absolute HTTP as well as HTTPS URLs for provider endpoints, base URLs, model discovery, and capability-specific routes
- keep malformed, relative, FTP, file, and other non-HTTP(S) endpoint values rejected
- show an inline plaintext-transport warning whenever an effective provider URL uses HTTP
- document Docker/service-name routing, the backend network perspective, and the recommendation to use HTTPS whenever TLS is available
- retain admin-only routing changes, same-user credentials for custom routes, and redirect blocking across Chat, Work, discovery, image generation, embeddings, and TTS

## Why

Addresses the self-deployed HTTP gateway follow-up in #163. The previous validation accepted HTTP only for loopback and private IPv4 literals, which blocked Docker, Kubernetes, and other hostname-based self-hosted gateways such as `http://ai-gateway:8080` and `http://host.docker.internal:8080`.

HTTP credentials and provider traffic are unencrypted, so the UI and documentation now warn administrators to use it only on a trusted network and to prefer HTTPS when available.

## Impact

Administrators can route supported providers through hostname-based HTTP gateways. Existing HTTPS configurations are unchanged. Other URL schemes, unsafe API paths, base-URL query strings/fragments, cross-user credential fallback, and provider redirects remain blocked.

## Checks

- `npm run format:check`
- `npm run lint`
- `npm run test:package`
- `npm run test:e2e` — 67 passed
- `node --test scripts/test-chat-context.mjs scripts/test-provider-api-modes.mjs scripts/test-plugin-endpoint-routing.mjs` — 99 passed
- focused admin provider settings Playwright regression after the final wording update — 1 passed
- pre-commit frontend/backend type checks