### PR TITLE
feat(theme): default new installs to dark mode

### DIFF
--- a/backend/src/services/preferencesService.ts
+++ b/backend/src/services/preferencesService.ts
@@ -41,7 +41,7 @@ class PreferencesService {
   private defaultPreferences: UserPreferences = {
     defaultModel: '',
     theme: {
-      mode: 'light',
+      mode: 'dark',
       adaptToAccent: false,
       accent: 'blue',
       customAccent: '#2563eb',

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -30,6 +30,96 @@ type TurnstileTestWindow = Window & {
   };
 };
 
+test('first-time setup defaults to dark mode', async ({ page }) => {
+  await mockLibreWebUiApi(page, {
+    systemInfo: {
+      requiresAuth: true,
+      hasUsers: false,
+      userCount: 0,
+      signupEnabled: true,
+      allowUserModelPull: true,
+      version: '0.17.0-e2e',
+      turnstile: { enabled: false },
+    },
+  });
+
+  await page.goto('/');
+
+  await expect(
+    page.getByRole('heading', { name: "Let's Get Started" })
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+});
+
+test('login and signup default to dark mode', async ({ page }) => {
+  await mockLibreWebUiApi(page, {
+    systemInfo: {
+      requiresAuth: true,
+      hasUsers: true,
+      userCount: 1,
+      signupEnabled: true,
+      allowUserModelPull: true,
+      version: '0.17.0-e2e',
+      turnstile: { enabled: false },
+    },
+  });
+
+  await page.goto('/login');
+
+  await expect(
+    page.getByRole('heading', { name: 'Welcome Back' })
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+  await expect(
+    page.getByRole('button', { name: 'Switch to light mode' })
+  ).toBeVisible();
+
+  await page.getByRole('button', { name: 'Sign up here' }).click();
+
+  await expect(
+    page.getByRole('heading', { name: 'Create Account' })
+  ).toBeVisible();
+  await expect(page.locator('html')).toHaveClass(/\bdark\b/);
+});
+
+test('login preserves an explicit light theme preference', async ({ page }) => {
+  const lightTheme = {
+    mode: 'light' as const,
+    adaptToAccent: false,
+    accent: 'blue',
+    customAccent: '#2563eb',
+  };
+
+  await page.addInitScript(theme => {
+    localStorage.setItem(
+      'libre-webui-app-state',
+      JSON.stringify({ state: { theme } })
+    );
+  }, lightTheme);
+
+  await mockLibreWebUiApi(page, {
+    systemInfo: {
+      requiresAuth: true,
+      hasUsers: true,
+      userCount: 1,
+      signupEnabled: true,
+      allowUserModelPull: true,
+      version: '0.17.0-e2e',
+      turnstile: { enabled: false },
+    },
+  });
+
+  await page.goto('/login');
+
+  await expect(
+    page.getByRole('heading', { name: 'Welcome Back' })
+  ).toBeVisible();
+  await expect(page.locator('html')).not.toHaveClass(/\bdark\b/);
+  await expect(
+    page.getByRole('button', { name: 'Switch to dark mode' })
+  ).toBeVisible();
+});
+
 test('demo mode login is click-only with disabled demo credentials', async ({
   page,
 }) => {

--- a/frontend/e2e/lib/mockApi.ts
+++ b/frontend/e2e/lib/mockApi.ts
@@ -27,6 +27,7 @@ type MockSystemInfo = {
   requiresAuth: boolean;
   hasUsers: boolean;
   userCount: number;
+  signupEnabled?: boolean;
   allowUserModelPull: boolean;
   version: string;
   turnstile?: { enabled: boolean; siteKey?: string };

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,26 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script>
+      (() => {
+        let mode = 'dark';
+
+        try {
+          const savedState = JSON.parse(
+            localStorage.getItem('libre-webui-app-state') || 'null'
+          );
+
+          if (savedState?.state?.theme?.mode === 'light') {
+            mode = 'light';
+          }
+        } catch {
+          // Keep the dark default when persisted state is unavailable or invalid.
+        }
+
+        document.documentElement.classList.toggle('dark', mode === 'dark');
+        document.documentElement.style.colorScheme = mode;
+      })();
+    </script>
     <!-- Always use dark favicon -->
     <link rel="icon" type="image/png" href="/favicon-dark.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "test:unit": "node --import tsx --test src/utils/workCode.test.ts src/utils/workEvents.test.ts src/utils/pluginEndpoint.test.ts src/utils/chatModelSelection.test.ts src/utils/imageGenModels.test.ts src/utils/api/workEventStream.test.ts src/utils/pluginVariableOverrides.test.ts src/utils/pluginProviderCatalog.test.ts src/utils/workDiff.test.ts src/i18n/workTranslations.test.ts src/store/pluginStore.test.ts",
+    "test:unit": "node --import tsx --test src/utils/workCode.test.ts src/utils/workEvents.test.ts src/utils/pluginEndpoint.test.ts src/utils/chatModelSelection.test.ts src/utils/imageGenModels.test.ts src/utils/api/workEventStream.test.ts src/utils/pluginVariableOverrides.test.ts src/utils/pluginProviderCatalog.test.ts src/utils/workDiff.test.ts src/utils/theme.test.ts src/i18n/workTranslations.test.ts src/store/pluginStore.test.ts",
     "e2e": "playwright test",
     "type-check": "tsc --noEmit",
     "lint": "eslint src/ e2e/ playwright.config.ts --ext .ts,.tsx,.js,.jsx --max-warnings 100",

--- a/frontend/src/hooks/useInitializeApp.ts
+++ b/frontend/src/hooks/useInitializeApp.ts
@@ -18,6 +18,7 @@
 import { useEffect, useRef } from 'react';
 import { useChatStore } from '@/store/chatStore';
 import { useAppStore } from '@/store/appStore';
+import { useAuthStore } from '@/store/authStore';
 import { usePluginStore } from '@/store/pluginStore';
 import { ollamaApi } from '@/utils/api';
 import { UserService } from '@/services/userService';
@@ -54,6 +55,15 @@ export const useInitializeApp = () => {
 
         // Initialize authentication first
         await UserService.initializeAuth();
+
+        const authState = useAuthStore.getState();
+        if (authState.requiresAuth() && !authState.isAuthenticated) {
+          logger.debug(
+            'Authentication required; deferring protected app initialization'
+          );
+          initialized.current = true;
+          return;
+        }
 
         // Ollama and configured plugins are independent model providers. An
         // unavailable Ollama daemon must not prevent the rest of the app (or

--- a/frontend/src/store/appStore.ts
+++ b/frontend/src/store/appStore.ts
@@ -21,8 +21,7 @@ import { UserPreferences, Theme, Artifact } from '@/types';
 import { isDemoMode, getDemoConfig } from '@/utils/demoMode';
 import {
   applyThemeToDocument,
-  DEFAULT_ACCENT,
-  DEFAULT_CUSTOM_ACCENT,
+  createDefaultTheme,
   normalizeTheme,
 } from '@/utils/theme';
 import { createLogger } from '@/utils/logger';
@@ -87,12 +86,7 @@ export const useAppStore = create<AppState>()(
   persist(
     (set, get) => ({
       // Theme
-      theme: {
-        mode: 'light',
-        adaptToAccent: false,
-        accent: DEFAULT_ACCENT,
-        customAccent: DEFAULT_CUSTOM_ACCENT,
-      },
+      theme: createDefaultTheme(),
       themeSyncPending: false,
       syncThemePreference: async theme => {
         if (themeSyncTimeout) {
@@ -185,12 +179,7 @@ export const useAppStore = create<AppState>()(
 
       // User preferences
       preferences: {
-        theme: {
-          mode: 'light',
-          adaptToAccent: false,
-          accent: DEFAULT_ACCENT,
-          customAccent: DEFAULT_CUSTOM_ACCENT,
-        },
+        theme: createDefaultTheme(),
         defaultModel: '',
         defaultProviderType: null,
         defaultProviderId: null,
@@ -378,12 +367,7 @@ export const useAppStore = create<AppState>()(
 
       // Clear user-specific state (called on logout/login to prevent data leaking between users)
       clearUserState: () => {
-        const defaultTheme = normalizeTheme({
-          mode: 'light',
-          adaptToAccent: false,
-          accent: DEFAULT_ACCENT,
-          customAccent: DEFAULT_CUSTOM_ACCENT,
-        });
+        const defaultTheme = createDefaultTheme();
 
         if (themeSyncTimeout) {
           clearTimeout(themeSyncTimeout);

--- a/frontend/src/utils/theme.test.ts
+++ b/frontend/src/utils/theme.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Libre WebUI
+ * Copyright (C) 2025 Kroonen AI, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createDefaultTheme, normalizeTheme } from './theme';
+
+test('uses dark mode when no theme preference exists', () => {
+  assert.equal(createDefaultTheme().mode, 'dark');
+  assert.equal(normalizeTheme().mode, 'dark');
+});
+
+test('preserves an explicit light theme preference', () => {
+  assert.equal(normalizeTheme({ mode: 'light' }).mode, 'light');
+});

--- a/frontend/src/utils/theme.ts
+++ b/frontend/src/utils/theme.ts
@@ -17,6 +17,7 @@
 
 import { Theme } from '@/types';
 
+export const DEFAULT_THEME_MODE: Theme['mode'] = 'dark';
 export const DEFAULT_ACCENT = 'blue';
 export const DEFAULT_CUSTOM_ACCENT = '#2563eb';
 
@@ -471,7 +472,7 @@ const createCustomPalette = (customAccent?: string): AccentPalette => {
 };
 
 export const normalizeTheme = (theme?: Partial<Theme> | null): Theme => {
-  const mode = theme?.mode === 'dark' ? 'dark' : 'light';
+  const mode = theme?.mode === 'light' ? 'light' : DEFAULT_THEME_MODE;
   const accent = theme?.accent === 'custom' ? 'custom' : theme?.accent;
   const presetAccent = ACCENT_OPTIONS.some(option => option.id === accent)
     ? accent
@@ -486,6 +487,9 @@ export const normalizeTheme = (theme?: Partial<Theme> | null): Theme => {
     customAccent,
   };
 };
+
+export const createDefaultTheme = (): Theme =>
+  normalizeTheme({ mode: DEFAULT_THEME_MODE });
 
 export const getAccentPalette = (theme?: Partial<Theme> | null) => {
   const normalizedTheme = normalizeTheme(theme);


### PR DESCRIPTION
## Summary

- make dark mode the shared frontend default for fresh installs, auth pages, and reset state
- create new backend user preferences with dark mode and apply the saved/default mode before React hydrates
- defer protected app initialization until authentication so login/signup theme choices are not reset by unauthorized preference requests
- cover first-time setup, login, signup, and explicit light-mode preservation

## Testing

- `npm run test:unit --workspace=frontend`
- `npm run e2e --workspace=frontend -- auth.spec.ts`
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `node --test scripts/test-pr-quality-gates.mjs`