### PR TITLE
feat(work): add guarded local Git workspace UI

### DIFF
--- a/backend/src/routes/work.ts
+++ b/backend/src/routes/work.ts
@@ -21,6 +21,7 @@ import {
   requireAdmin,
   AuthenticatedRequest,
 } from '../middleware/auth.js';
+import { userModel } from '../models/userModel.js';
 import workAgentService from '../services/workAgentService.js';
 import workEventService, {
   WORK_EVENT_MAX_RESUME_CURSOR,
@@ -36,6 +37,8 @@ import workTaskService, {
 } from '../services/workTaskService.js';
 import {
   WorkCapabilities,
+  WorkGitDiff,
+  WorkGitStatus,
   WorkLiveEvent,
   WorkMessagePage,
   WorkProviderSelection,
@@ -695,6 +698,156 @@ router.put(
   }
 );
 
+router.get(
+  '/tasks/:id/git',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitStatus>>
+  ): Promise<void> => {
+    try {
+      const task = workTaskService.requireMutableTaskRecord(
+        readTaskId(req),
+        requireUserId(req)
+      );
+      sendSuccess(res, await workRuntimeService.getGitStatus(task));
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
+router.get(
+  '/tasks/:id/git/diff',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitDiff>>
+  ): Promise<void> => {
+    try {
+      const task = workTaskService.requireMutableTaskRecord(
+        readTaskId(req),
+        requireUserId(req)
+      );
+      const requestedPath =
+        typeof req.query.path === 'string' ? req.query.path : undefined;
+      sendSuccess(
+        res,
+        await workRuntimeService.getGitDiff(task, requestedPath)
+      );
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
+router.post(
+  '/tasks/:id/git/init',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitStatus>>
+  ): Promise<void> => {
+    try {
+      const task = requireIdleGitTask(req);
+      sendSuccess(res, await workRuntimeService.initializeGit(task));
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
+router.post(
+  '/tasks/:id/git/stage',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitStatus>>
+  ): Promise<void> => {
+    try {
+      if (
+        !Array.isArray(req.body?.paths) ||
+        req.body.paths.some((value: unknown) => typeof value !== 'string')
+      ) {
+        throw new WorkRouteError('Field "paths" must be a string array.', 400);
+      }
+      const task = requireIdleGitTask(req);
+      sendSuccess(
+        res,
+        await workRuntimeService.stageGitPaths(task, req.body.paths)
+      );
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
+router.post(
+  '/tasks/:id/git/commit',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitStatus>>
+  ): Promise<void> => {
+    try {
+      const userId = requireUserId(req);
+      const task = requireIdleGitTask(req);
+      const user = userModel.getUserById(userId);
+      if (!user) throw new WorkRouteError('User account was not found.', 404);
+      sendSuccess(
+        res,
+        await workRuntimeService.commitGit(
+          task,
+          requireBodyString(req.body?.message, 'message', 4_000),
+          {
+            name: user.username,
+            email: user.email || `${user.id}@users.noreply.libre-webui.local`,
+          }
+        )
+      );
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
+router.post(
+  '/tasks/:id/git/branches',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitStatus>>
+  ): Promise<void> => {
+    try {
+      const task = requireIdleGitTask(req);
+      sendSuccess(
+        res,
+        await workRuntimeService.createGitBranch(
+          task,
+          requireBodyString(req.body?.name, 'name', 200)
+        )
+      );
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
+router.post(
+  '/tasks/:id/git/switch',
+  async (
+    req: AuthenticatedRequest,
+    res: Response<ApiResponse<WorkGitStatus>>
+  ): Promise<void> => {
+    try {
+      const task = requireIdleGitTask(req);
+      sendSuccess(
+        res,
+        await workRuntimeService.switchGitBranch(
+          task,
+          requireBodyString(req.body?.name, 'name', 200)
+        )
+      );
+    } catch (error) {
+      sendError(res, error);
+    }
+  }
+);
+
 router.post(
   '/tasks/:id/preview/start',
   async (
@@ -760,6 +913,21 @@ function requireUserId(req: AuthenticatedRequest): string {
 
 function readTaskId(req: AuthenticatedRequest): string {
   return String(req.params.id || '').trim();
+}
+
+function requireIdleGitTask(req: AuthenticatedRequest): WorkTaskRecord {
+  const taskId = readTaskId(req);
+  const task = workTaskService.requireMutableTaskRecord(
+    taskId,
+    requireUserId(req)
+  );
+  if (workTaskService.getActiveRun(taskId)) {
+    throw new WorkRouteError(
+      'Stop the active Work run before changing Git state.',
+      409
+    );
+  }
+  return task;
 }
 
 function readProviderSelection(

--- a/backend/src/services/workRuntimeService.ts
+++ b/backend/src/services/workRuntimeService.ts
@@ -19,8 +19,21 @@ import { spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import path from 'node:path';
 import { getDatabase } from '../db.js';
-import { WorkFileEntry, WorkTaskRecord } from '../types/work.js';
+import {
+  WorkFileEntry,
+  WorkGitDiff,
+  WorkGitStatus,
+  WorkTaskRecord,
+} from '../types/work.js';
 import { createLogger } from '../utils/logger.js';
+import {
+  buildWorkGitCommand,
+  parseWorkGitBranches,
+  parseWorkGitLog,
+  parseWorkGitStatus,
+  validateWorkGitBranchName,
+  validateWorkGitRepositoryPaths,
+} from '../utils/workGit.js';
 import workPreviewProxyService from './workPreviewProxyService.js';
 
 const logger = createLogger('services:work-runtime');
@@ -887,7 +900,19 @@ export class WorkRuntimeService {
         task,
         ['node', '-e', READ_FILE_SCRIPT, '--', workspacePath],
         // JSON may escape each input byte as a six-character Unicode sequence.
-        { maxOutputChars: 12_100_000 }
+        { maxOutputChars: 12_100_000, acceptFailure: true }
+      );
+      if (result.exitCode === 24) {
+        throw new WorkRuntimeError(
+          'This file is not valid UTF-8 and cannot be opened in the text editor.',
+          415,
+          'WORK_FILE_NOT_UTF8'
+        );
+      }
+      this.assertSuccessfulHelperCommand(
+        result,
+        'The workspace file could not be read.',
+        'WORK_FILE_READ_FAILED'
       );
       const payload = parseJsonOutput<{
         content: string;
@@ -899,6 +924,198 @@ export class WorkRuntimeService {
         ...payload,
         modifiedAt: payload.updatedAt,
       };
+    });
+  }
+
+  async getGitStatus(task: WorkTaskRecord): Promise<WorkGitStatus> {
+    return this.withWorkspaceHelperContainer(task, () =>
+      this.loadGitStatus(task)
+    );
+  }
+
+  async getGitDiff(
+    task: WorkTaskRecord,
+    requestedPath?: string
+  ): Promise<WorkGitDiff> {
+    const workspacePath = requestedPath
+      ? validateWorkspacePath(requestedPath, false)
+      : undefined;
+    return this.withWorkspaceHelperContainer(task, async () => {
+      const status = await this.loadGitStatus(task);
+      if (!status.initialized) {
+        throw new WorkRuntimeError(
+          'Initialize Git before requesting a diff.',
+          409,
+          'WORK_GIT_NOT_INITIALIZED'
+        );
+      }
+      const revisionArgs = status.head ? ['HEAD'] : ['--cached'];
+      const result = await this.execGit(
+        task,
+        [
+          'diff',
+          ...revisionArgs,
+          '--no-ext-diff',
+          '--no-textconv',
+          '--',
+          ...(workspacePath ? [workspacePath] : []),
+        ],
+        { maxOutputChars: 600_000 }
+      );
+      return {
+        ...(workspacePath ? { path: workspacePath } : {}),
+        patch: result.stdout,
+        truncated: result.truncated,
+      };
+    });
+  }
+
+  async initializeGit(task: WorkTaskRecord): Promise<WorkGitStatus> {
+    return this.withGitMutation(task, async () => {
+      const current = await this.loadGitStatus(task);
+      if (current.initialized) return current;
+      await this.requireGitSuccess(
+        task,
+        ['init', '--initial-branch=main', '--template=', '.'],
+        'Git could not initialize this workspace.'
+      );
+      return this.loadGitStatus(task);
+    });
+  }
+
+  async stageGitPaths(
+    task: WorkTaskRecord,
+    requestedPaths: string[]
+  ): Promise<WorkGitStatus> {
+    if (requestedPaths.length < 1 || requestedPaths.length > 200) {
+      throw new WorkRuntimeError(
+        'Choose between 1 and 200 workspace paths to stage.',
+        400,
+        'WORK_GIT_INVALID_PATHS'
+      );
+    }
+    const workspacePaths = [
+      ...new Set(
+        requestedPaths.map(value => validateWorkspacePath(value, false))
+      ),
+    ];
+    return this.withGitMutation(task, async () => {
+      await this.requireGitRepository(task);
+      await this.assertNoExecutableGitFilters(task);
+      await this.requireGitSuccess(
+        task,
+        ['add', '--all', '--', ...workspacePaths],
+        'Git could not stage the selected paths.'
+      );
+      return this.loadGitStatus(task);
+    });
+  }
+
+  async commitGit(
+    task: WorkTaskRecord,
+    message: string,
+    identity: { name: string; email: string }
+  ): Promise<WorkGitStatus> {
+    const commitMessage = message.trim();
+    if (
+      !commitMessage ||
+      commitMessage.length > 4_000 ||
+      commitMessage.includes('\0')
+    ) {
+      throw new WorkRuntimeError(
+        'Commit message must contain between 1 and 4,000 characters.',
+        400,
+        'WORK_GIT_INVALID_COMMIT_MESSAGE'
+      );
+    }
+    const name = validateGitIdentity(identity.name, 'name');
+    const email = validateGitIdentity(identity.email, 'email');
+    return this.withGitMutation(task, async () => {
+      await this.requireGitRepository(task);
+      await this.requireGitSuccess(
+        task,
+        [
+          '-c',
+          `user.name=${name}`,
+          '-c',
+          `user.email=${email}`,
+          'commit',
+          '--no-verify',
+          '-m',
+          commitMessage,
+        ],
+        'Git could not create the commit.'
+      );
+      return this.loadGitStatus(task);
+    });
+  }
+
+  async createGitBranch(
+    task: WorkTaskRecord,
+    requestedName: string
+  ): Promise<WorkGitStatus> {
+    const branchName = validateGitBranchInput(requestedName);
+    return this.withGitMutation(task, async () => {
+      const status = await this.loadGitStatus(task);
+      if (!status.initialized) {
+        throw new WorkRuntimeError(
+          'Initialize Git before creating a branch.',
+          409,
+          'WORK_GIT_NOT_INITIALIZED'
+        );
+      }
+      if (!status.head) {
+        throw new WorkRuntimeError(
+          'Create the first commit before creating another branch.',
+          409,
+          'WORK_GIT_UNBORN_BRANCH'
+        );
+      }
+      await this.requireValidGitBranch(task, branchName);
+      await this.requireGitSuccess(
+        task,
+        ['branch', branchName],
+        'Git could not create the branch.'
+      );
+      return this.loadGitStatus(task);
+    });
+  }
+
+  async switchGitBranch(
+    task: WorkTaskRecord,
+    requestedName: string
+  ): Promise<WorkGitStatus> {
+    const branchName = validateGitBranchInput(requestedName);
+    return this.withGitMutation(task, async () => {
+      const status = await this.loadGitStatus(task);
+      if (!status.initialized) {
+        throw new WorkRuntimeError(
+          'Initialize Git before switching branches.',
+          409,
+          'WORK_GIT_NOT_INITIALIZED'
+        );
+      }
+      if (status.changes.length > 0) {
+        throw new WorkRuntimeError(
+          'Commit or discard workspace changes before switching branches.',
+          409,
+          'WORK_GIT_DIRTY_WORKTREE'
+        );
+      }
+      if (!status.branches.includes(branchName)) {
+        throw new WorkRuntimeError(
+          'Only an existing local branch can be selected.',
+          400,
+          'WORK_GIT_UNKNOWN_BRANCH'
+        );
+      }
+      await this.assertNoExecutableGitFilters(task);
+      await this.requireGitSuccess(
+        task,
+        ['switch', '--no-guess', branchName],
+        'Git could not switch branches.'
+      );
+      return this.loadGitStatus(task);
     });
   }
 
@@ -1873,6 +2090,243 @@ export class WorkRuntimeService {
     }
   }
 
+  private async withGitMutation<T>(
+    task: WorkTaskRecord,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    this.assertGitMutationIdle(task.id);
+    return this.withWorkspaceHelperContainer(task, async () => {
+      this.assertGitMutationIdle(task.id);
+      return operation();
+    });
+  }
+
+  private assertGitMutationIdle(taskId: string): void {
+    if (
+      this.activeCommands.has(taskId) ||
+      (this.terminalHolds.get(taskId) ?? 0) > 0 ||
+      this.previewLeaseReleases.has(taskId)
+    ) {
+      throw new WorkRuntimeError(
+        'Stop the active Work run, terminal, and preview before changing Git state.',
+        409,
+        'WORK_GIT_RUNTIME_BUSY'
+      );
+    }
+  }
+
+  private async loadGitStatus(task: WorkTaskRecord): Promise<WorkGitStatus> {
+    if (!(await this.probeGitRepository(task))) {
+      return {
+        initialized: false,
+        detached: false,
+        ahead: 0,
+        behind: 0,
+        changes: [],
+        branches: [],
+        commits: [],
+      };
+    }
+    const statusResult = await this.execGit(
+      task,
+      ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'],
+      { maxOutputChars: 2_000_000 }
+    );
+    if (statusResult.truncated) {
+      throw new WorkRuntimeError(
+        'Git status is too large to display safely.',
+        413,
+        'WORK_GIT_STATUS_TOO_LARGE'
+      );
+    }
+    const status = parseWorkGitStatus(statusResult.stdout);
+    const branchesResult = await this.execGit(
+      task,
+      ['for-each-ref', '--format=%(refname:short)', 'refs/heads'],
+      { maxOutputChars: 100_000 }
+    );
+    if (branchesResult.truncated) {
+      throw new WorkRuntimeError(
+        'The local branch list is too large to display safely.',
+        413,
+        'WORK_GIT_BRANCHES_TOO_LARGE'
+      );
+    }
+    status.branches = parseWorkGitBranches(branchesResult.stdout);
+    if (status.branch && !status.branches.includes(status.branch)) {
+      status.branches.unshift(status.branch);
+    }
+    if (status.head) {
+      const logResult = await this.execGit(
+        task,
+        ['log', '-n', '20', '--format=format:%H%x00%h%x00%an%x00%aI%x00%s%x00'],
+        { maxOutputChars: 200_000 }
+      );
+      if (logResult.truncated) {
+        throw new WorkRuntimeError(
+          'Git history is too large to display safely.',
+          413,
+          'WORK_GIT_HISTORY_TOO_LARGE'
+        );
+      }
+      status.commits = parseWorkGitLog(logResult.stdout);
+    }
+    return status;
+  }
+
+  private async probeGitRepository(task: WorkTaskRecord): Promise<boolean> {
+    const result = await this.execGit(
+      task,
+      [
+        'rev-parse',
+        '--path-format=absolute',
+        '--show-toplevel',
+        '--git-dir',
+        '--git-common-dir',
+      ],
+      { acceptFailure: true, maxOutputChars: 20_000 }
+    );
+    if (result.exitCode === 127) {
+      throw new WorkRuntimeError(
+        'Git is not installed in the configured Work runtime image.',
+        503,
+        'WORK_GIT_UNAVAILABLE'
+      );
+    }
+    if (result.exitCode !== 0) return false;
+    try {
+      validateWorkGitRepositoryPaths(result.stdout);
+    } catch (error) {
+      throw new WorkRuntimeError(
+        error instanceof Error
+          ? error.message
+          : 'Git repository layout is unsafe.',
+        409,
+        'WORK_GIT_UNSAFE_REPOSITORY'
+      );
+    }
+    const [, gitDirectory, commonDirectory] = result.stdout
+      .trimEnd()
+      .split('\n');
+    const realPathCheck = await this.exec(
+      task,
+      [
+        'node',
+        '-e',
+        VALIDATE_GIT_REPOSITORY_PATHS_SCRIPT,
+        '--',
+        gitDirectory,
+        commonDirectory,
+      ],
+      { acceptFailure: true, maxOutputChars: 10_000 }
+    );
+    if (realPathCheck.exitCode !== 0) {
+      throw new WorkRuntimeError(
+        'Git metadata must resolve inside /workspace.',
+        409,
+        'WORK_GIT_UNSAFE_REPOSITORY'
+      );
+    }
+    return true;
+  }
+
+  private async requireGitRepository(task: WorkTaskRecord): Promise<void> {
+    if (await this.probeGitRepository(task)) return;
+    throw new WorkRuntimeError(
+      'Initialize Git before changing repository state.',
+      409,
+      'WORK_GIT_NOT_INITIALIZED'
+    );
+  }
+
+  private async assertNoExecutableGitFilters(
+    task: WorkTaskRecord
+  ): Promise<void> {
+    const result = await this.execGit(
+      task,
+      [
+        'config',
+        '--includes',
+        '--get-regexp',
+        '^filter\\..*\\.(clean|smudge|process)$',
+      ],
+      { acceptFailure: true, maxOutputChars: 20_000 }
+    );
+    if (result.exitCode > 1) {
+      this.throwGitFailure(result, 'Git configuration could not be inspected.');
+    }
+    if (result.stdout.trim()) {
+      throw new WorkRuntimeError(
+        'This repository configures executable Git filters. Remove them before using Git write actions in Work.',
+        409,
+        'WORK_GIT_EXECUTABLE_FILTER_BLOCKED'
+      );
+    }
+  }
+
+  private async requireValidGitBranch(
+    task: WorkTaskRecord,
+    branchName: string
+  ): Promise<void> {
+    const result = await this.execGit(
+      task,
+      ['check-ref-format', '--branch', branchName],
+      { acceptFailure: true, maxOutputChars: 10_000 }
+    );
+    if (result.exitCode !== 0) {
+      throw new WorkRuntimeError(
+        'Branch name is invalid.',
+        400,
+        'WORK_GIT_INVALID_BRANCH'
+      );
+    }
+  }
+
+  private async requireGitSuccess(
+    task: WorkTaskRecord,
+    args: string[],
+    fallbackMessage: string
+  ): Promise<ProcessResult> {
+    const result = await this.execGit(task, args, {
+      acceptFailure: true,
+      maxOutputChars: 100_000,
+    });
+    if (result.exitCode !== 0) this.throwGitFailure(result, fallbackMessage);
+    return result;
+  }
+
+  private throwGitFailure(
+    result: ProcessResult,
+    fallbackMessage: string
+  ): never {
+    throw new WorkRuntimeError(
+      result.stderr.trim() || result.stdout.trim() || fallbackMessage,
+      409,
+      'WORK_GIT_COMMAND_FAILED'
+    );
+  }
+
+  private assertSuccessfulHelperCommand(
+    result: ProcessResult,
+    fallbackMessage: string,
+    code: string
+  ): void {
+    if (result.exitCode === 0) return;
+    throw new WorkRuntimeError(
+      result.stderr.trim() || result.stdout.trim() || fallbackMessage,
+      503,
+      code
+    );
+  }
+
+  private async execGit(
+    task: WorkTaskRecord,
+    args: string[],
+    options: ProcessOptions = {}
+  ): Promise<ProcessResult> {
+    return this.exec(task, buildWorkGitCommand(args), options);
+  }
+
   private async exec(
     task: WorkTaskRecord,
     command: string[],
@@ -2030,6 +2484,34 @@ export function validateWorkspacePath(input: string, allowRoot = true): string {
     );
   }
   return canonical;
+}
+
+function validateGitBranchInput(input: string): string {
+  try {
+    return validateWorkGitBranchName(input);
+  } catch {
+    throw new WorkRuntimeError(
+      'Branch name is invalid.',
+      400,
+      'WORK_GIT_INVALID_BRANCH'
+    );
+  }
+}
+
+function validateGitIdentity(value: string, field: 'name' | 'email'): string {
+  const maximum = field === 'name' ? 200 : 320;
+  const hasControlCharacter = [...value].some(character => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+  if (!value || value.length > maximum || hasControlCharacter) {
+    throw new WorkRuntimeError(
+      `Git ${field} is invalid.`,
+      400,
+      'WORK_GIT_INVALID_IDENTITY'
+    );
+  }
+  return value;
 }
 
 export function parsePublishedPort(
@@ -2283,6 +2765,22 @@ const inside = candidate => candidate === rootReal || candidate.startsWith(rootR
 const rel = process.argv[1] || '.';
 const target = path.resolve(root, rel);
 if (!inside(target)) throw new Error('Path escapes workspace');
+`;
+
+const VALIDATE_GIT_REPOSITORY_PATHS_SCRIPT = String.raw`
+const fs = require('node:fs');
+const path = require('node:path');
+const root = fs.realpathSync('/workspace');
+const inside = candidate => candidate === root || candidate.startsWith(root + path.sep);
+for (const candidate of process.argv.slice(1)) {
+  let resolved;
+  try {
+    resolved = fs.realpathSync(candidate);
+  } catch {
+    process.exit(25);
+  }
+  if (!inside(resolved) || !fs.statSync(resolved).isDirectory()) process.exit(25);
+}
 `;
 
 const PREVIEW_READY_SCRIPT = String.raw`
@@ -2597,8 +3095,14 @@ if (!inside(targetReal)) throw new Error('Path escapes workspace');
 const stat = fs.statSync(targetReal);
 if (!stat.isFile()) throw new Error('Path is not a file');
 if (stat.size > 2000000) throw new Error('File exceeds 2 MB limit');
+let content;
+try {
+  content = new TextDecoder('utf-8', {fatal:true}).decode(fs.readFileSync(targetReal));
+} catch {
+  process.exit(24);
+}
 console.log(JSON.stringify({
-  content: fs.readFileSync(targetReal, 'utf8'),
+  content,
   size: stat.size,
   updatedAt: stat.mtimeMs
 }));

--- a/backend/src/types/work.ts
+++ b/backend/src/types/work.ts
@@ -240,6 +240,41 @@ export interface WorkFileEntry {
   modifiedAt: number;
 }
 
+export interface WorkGitChange {
+  path: string;
+  originalPath?: string;
+  indexStatus: string;
+  workingTreeStatus: string;
+  staged: boolean;
+}
+
+export interface WorkGitCommit {
+  hash: string;
+  shortHash: string;
+  author: string;
+  authoredAt: string;
+  subject: string;
+}
+
+export interface WorkGitStatus {
+  initialized: boolean;
+  branch?: string;
+  detached: boolean;
+  head?: string;
+  upstream?: string;
+  ahead: number;
+  behind: number;
+  changes: WorkGitChange[];
+  branches: string[];
+  commits: WorkGitCommit[];
+}
+
+export interface WorkGitDiff {
+  path?: string;
+  patch: string;
+  truncated: boolean;
+}
+
 export interface WorkCapabilities {
   available: boolean;
   runtime: 'docker';

--- a/backend/src/utils/workGit.ts
+++ b/backend/src/utils/workGit.ts
@@ -1,0 +1,218 @@
+/*
+ * Libre WebUI
+ * Copyright (C) 2025 Kroonen AI, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import path from 'node:path';
+import { WorkGitChange, WorkGitCommit, WorkGitStatus } from '../types/work.js';
+
+const WORKSPACE_ROOT = '/workspace';
+
+/**
+ * Git always runs as an argv array inside the task sandbox. These settings
+ * remove host/global configuration, prompts, hooks, credential helpers and
+ * protocols from the local-only UI surface.
+ */
+export function buildWorkGitCommand(args: string[]): string[] {
+  return [
+    'env',
+    'HOME=/tmp',
+    'GIT_CONFIG_NOSYSTEM=1',
+    'GIT_CONFIG_GLOBAL=/dev/null',
+    'GIT_TERMINAL_PROMPT=0',
+    'GIT_ASKPASS=/bin/false',
+    'SSH_ASKPASS=/bin/false',
+    'git',
+    '--no-pager',
+    '--literal-pathspecs',
+    '-c',
+    'core.hooksPath=/dev/null',
+    '-c',
+    'core.fsmonitor=false',
+    '-c',
+    'core.attributesFile=/dev/null',
+    '-c',
+    'credential.helper=',
+    '-c',
+    'commit.gpgSign=false',
+    '-c',
+    'gc.auto=0',
+    '-c',
+    'maintenance.auto=false',
+    '-c',
+    'submodule.recurse=false',
+    '-c',
+    'protocol.allow=never',
+    ...args,
+  ];
+}
+
+/** Reject repositories whose worktree or Git metadata escapes the sandbox. */
+export function validateWorkGitRepositoryPaths(output: string): void {
+  const values = output.trimEnd().split('\n');
+  if (values.length !== 3 || values.some(hasControlCharacter)) {
+    throw new Error('Git returned an invalid repository layout.');
+  }
+  const [worktree, gitDirectory, commonDirectory] = values;
+  if (worktree !== WORKSPACE_ROOT) {
+    throw new Error('The Git worktree must be exactly /workspace.');
+  }
+  if (!isInsideWorkspace(gitDirectory) || !isInsideWorkspace(commonDirectory)) {
+    throw new Error('Git metadata must stay inside /workspace.');
+  }
+}
+
+export function validateWorkGitBranchName(value: string): string {
+  if (
+    value.length < 1 ||
+    value.length > 200 ||
+    value !== value.trim() ||
+    value.startsWith('-') ||
+    hasControlCharacter(value)
+  ) {
+    throw new Error('Branch name is invalid.');
+  }
+  return value;
+}
+
+export function parseWorkGitStatus(output: string): WorkGitStatus {
+  const status: WorkGitStatus = {
+    initialized: true,
+    detached: false,
+    ahead: 0,
+    behind: 0,
+    changes: [],
+    branches: [],
+    commits: [],
+  };
+  const records = output.split('\0');
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record) continue;
+    if (record.startsWith('# branch.oid ')) {
+      const oid = record.slice('# branch.oid '.length);
+      if (oid !== '(initial)') status.head = oid;
+      continue;
+    }
+    if (record.startsWith('# branch.head ')) {
+      const branch = record.slice('# branch.head '.length);
+      if (branch === '(detached)') status.detached = true;
+      else status.branch = branch;
+      continue;
+    }
+    if (record.startsWith('# branch.upstream ')) {
+      status.upstream = record.slice('# branch.upstream '.length);
+      continue;
+    }
+    if (record.startsWith('# branch.ab ')) {
+      const match = record.match(/^# branch\.ab \+(\d+) -(\d+)$/);
+      if (match) {
+        status.ahead = Number(match[1]);
+        status.behind = Number(match[2]);
+      }
+      continue;
+    }
+
+    let change: WorkGitChange | undefined;
+    if (record.startsWith('1 ')) {
+      change = parseTrackedChange(record, 8);
+    } else if (record.startsWith('2 ')) {
+      change = parseTrackedChange(record, 9);
+      const originalPath = records[index + 1];
+      if (change && originalPath !== undefined) {
+        change.originalPath = originalPath;
+        index += 1;
+      }
+    } else if (record.startsWith('u ')) {
+      change = parseTrackedChange(record, 10);
+    } else if (record.startsWith('? ')) {
+      change = {
+        path: record.slice(2),
+        indexStatus: '?',
+        workingTreeStatus: '?',
+        staged: false,
+      };
+    }
+    if (change) status.changes.push(change);
+  }
+  status.changes.sort((left, right) => left.path.localeCompare(right.path));
+  return status;
+}
+
+export function parseWorkGitLog(output: string): WorkGitCommit[] {
+  const fields = output.split('\0');
+  const commits: WorkGitCommit[] = [];
+  for (let index = 0; index + 4 < fields.length; index += 5) {
+    const [hash, shortHash, author, authoredAt, subject] = fields.slice(
+      index,
+      index + 5
+    );
+    if (!hash) continue;
+    commits.push({ hash, shortHash, author, authoredAt, subject });
+  }
+  return commits;
+}
+
+export function parseWorkGitBranches(output: string): string[] {
+  return output
+    .split('\n')
+    .map(value => value.trim())
+    .filter(value => value && !hasControlCharacter(value))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function parseTrackedChange(
+  record: string,
+  prefixFieldCount: number
+): WorkGitChange | undefined {
+  const fields = splitPrefixFields(record, prefixFieldCount);
+  const xy = fields[1];
+  const filePath = fields[prefixFieldCount];
+  if (!xy || xy.length !== 2 || !filePath) return undefined;
+  return {
+    path: filePath,
+    indexStatus: xy[0],
+    workingTreeStatus: xy[1],
+    staged: xy[0] !== '.' && xy[0] !== '?',
+  };
+}
+
+function splitPrefixFields(value: string, count: number): string[] {
+  const fields: string[] = [];
+  let start = 0;
+  for (let index = 0; index < count; index += 1) {
+    const separator = value.indexOf(' ', start);
+    if (separator < 0) return [];
+    fields.push(value.slice(start, separator));
+    start = separator + 1;
+  }
+  fields.push(value.slice(start));
+  return fields;
+}
+
+function isInsideWorkspace(value: string): boolean {
+  if (!path.posix.isAbsolute(value)) return false;
+  const normalized = path.posix.normalize(value);
+  return (
+    normalized === WORKSPACE_ROOT || normalized.startsWith(`${WORKSPACE_ROOT}/`)
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some(character => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}

--- a/docs/33-WORKSPACES.md
+++ b/docs/33-WORKSPACES.md
@@ -60,7 +60,7 @@ This release introduces Work as a complete task workflow:
 - A responsive Conversation/Workspace split with draggable, keyboard
   accessible sizing on desktop and a focused surface switcher on smaller
   screens.
-- Integrated Files, Activity, and Preview views.
+- Integrated Files, Activity, Git, Terminal, and Preview views.
 - Dark- and light-mode syntax highlighting, browser-side code formatting,
   save conflict detection, and temporary unsaved drafts.
 - A dismissible, per-user disclosure when a remote model provider is selected.
@@ -215,8 +215,10 @@ to switch surfaces.
 
 ### Files
 
-The Files tab browses direct children of `/workspace`, opens UTF-8 text files,
-and saves changes back to the task volume.
+The Files tab browses direct children of `/workspace`, opens strictly valid
+UTF-8 text files, and saves changes back to the task volume. Invalid byte
+sequences are rejected instead of being replaced with lossy placeholder
+characters.
 
 The editor provides:
 
@@ -272,6 +274,48 @@ supported independently of reasoning.
 Output is deliberately bounded. A truncated result is not proof that a command
 produced no additional output; ask the model to inspect a narrower result or
 run a more focused command.
+
+### Git
+
+The Git tab provides local source-control operations for the task's own
+`/workspace`:
+
+- initialize a repository with a `main` branch;
+- inspect porcelain status, ahead/behind counts, and up to 20 recent commits;
+- inspect a bounded textual diff for a changed path;
+- stage up to 200 explicitly selected paths at a time;
+- commit staged changes using the signed-in administrator's username and
+  email, or an instance-local no-reply address when the account has no email;
+- create a local branch after the first commit; and
+- switch to an existing local branch when the worktree is clean.
+
+This surface is intentionally **local-only**. It has no clone, fetch, pull,
+push, remote-management, arbitrary Git-command, token, SSH-key, or pull-request
+control. Those operations need a separate trusted credential broker, ideally a
+GitHub App or equivalent installation token scoped to one repository and one
+operation. Do not put long-lived Git credentials in `/workspace`, the task
+container environment, or repository configuration.
+
+Git reads can run while the task is otherwise idle or active. Git writes are
+rejected while a model run, interactive terminal, or preview owns the task
+container. Branch switching additionally requires a clean worktree. This
+prevents the UI from racing the model or a long-lived process over the same
+files.
+
+Every UI Git command is a fixed argument array executed as UID/GID `1000:1000`
+inside the task container; user input is never evaluated by a shell. The
+runtime disables system/global Git configuration, prompts, hooks, credential
+helpers, commit signing, submodule recursion, external diff drivers, textconv,
+and network protocols for this surface. It refuses repositories whose
+worktree is not exactly `/workspace` or whose Git/common directory resolves
+outside `/workspace`. Git write actions that could process file content are
+also blocked when repository configuration defines an executable clean,
+smudge, or process filter.
+
+These controls protect the Libre WebUI Git API. An administrator can still use
+the Terminal, and the model can still use `run_command`, to run ordinary Git
+commands inside the sandbox. The sandbox and deployment boundary therefore
+remain the security controls for arbitrary commands.
 
 ### Built-in worker skills
 
@@ -586,6 +630,87 @@ Work volumes do not have an independent disk quota. A generated project or
 package installation can exhaust Docker storage. Monitor volume growth and
 apply host-level storage limits where needed.
 
+## Production Hardening Checklist
+
+The application can set container flags, validate workspace paths, and guard
+its own API. It cannot enforce host firewall policy, storage-driver quotas, or
+the privilege level of the Docker daemon it is given. Treat these as explicit
+deployment work for a private client instance.
+
+### 1. Isolate Docker control
+
+The main Libre WebUI container needs daemon control to create and inspect Work
+containers. A mounted Docker socket is therefore a control-plane credential,
+not an ordinary data mount: compromising the web application can become a
+Docker-host compromise.
+
+For a stronger production boundary, run Libre WebUI and its Work daemon on a
+dedicated VM with no unrelated workloads. Stronger still, give Work a
+dedicated rootless Docker daemon or a separate runtime host and expose only
+that daemon to Libre WebUI. Verify file ownership, preview routing, cleanup,
+and terminal support against that daemon before rollout. Merely mounting the
+same rootful host socket read-only does not make the Docker API read-only.
+
+### 2. Block sandbox-to-host management access
+
+Disabling inter-container communication prevents Work sandboxes from reaching
+one another; it does not prevent them from reaching services bound on the
+Docker host. Inspect the actual managed bridge and subnet rather than assuming
+an address:
+
+```bash
+docker network inspect libre-webui-work \
+  --format 'id={{.Id}} subnets={{range .IPAM.Config}}{{.Subnet}} {{end}}'
+ss -lntup
+```
+
+Use the host's persistent firewall manager to reject traffic arriving from
+that bridge to host management services, especially SSH, the Docker API,
+databases, and monitoring/admin ports. Test the rule from a disposable
+container attached to `libre-webui-work`, test allowed package downloads, then
+make the rule persistent. Docker's `DOCKER-USER` chain controls forwarded
+traffic; traffic whose destination is the Docker host itself may need an
+`INPUT`/input-hook rule on the bridge interface as well.
+
+### 3. Constrain outbound destinations
+
+Block cloud metadata endpoints, private infrastructure ranges, and client LAN
+ranges from the Work subnet unless a project explicitly needs them. Combine a
+filtering resolver through `WORK_RUNTIME_DNS` with host or upstream firewall
+rules. DNS filtering alone is bypassable with a literal IP address. An HTTP
+proxy alone is also insufficient while arbitrary commands can open direct
+network connections; enforce the routing policy outside the container.
+
+Maintain separate profiles when clients need different behavior, for example
+an offline/no-network runtime, a package-registry-only runtime, and an open
+egress runtime. Libre WebUI currently creates networked UI tasks, so those
+profiles require operator-owned network policy rather than a cosmetic UI
+toggle.
+
+### 4. Enforce real storage quotas
+
+CPU, memory, swap, and PID limits do not limit the named volume. Before serving
+multiple clients, choose a storage backend with enforceable per-workspace
+quotas: for example XFS project quotas, quota-backed logical volumes, or a
+volume/PVC driver with a size limit. The default Docker `local` driver on an
+ordinary ext4 filesystem does not gain a reliable per-volume quota merely by
+documenting a size value.
+
+Monitor both each `ai.libre-webui.managed=true` volume and the Docker data root,
+alert before the filesystem is full, and test the failure mode. A UI counter or
+periodic `du` check can warn, but it is not an enforcement boundary because a
+container can consume the remaining disk between checks.
+
+### 5. Verify the deployed policy
+
+After every image or daemon-policy change, create a disposable Work task and
+verify the effective state with `docker inspect`: non-root UID, read-only root,
+all capabilities dropped, `no-new-privileges`, memory/swap/CPU/PID limits,
+only the task volume mounted, and the expected network. Also verify that the
+main Libre WebUI container has only the intended mounts and that public ingress
+reaches the app through the authenticated reverse proxy or tunnel—not through
+an accidentally published Docker or preview port.
+
 ## Preview Security and Reachability
 
 For each task, Docker publishes the configured container preview port to a
@@ -740,6 +865,11 @@ admission limit return HTTP 429.
 | Persisted tool output                  | About 20,000 source characters plus a marker                |
 | Live editor highlighting               | 8,000 characters and 400 lines                              |
 | Browser-side formatting                | 100,000 characters and 4,000 lines                          |
+| Git status output                      | 2,000,000 captured characters                               |
+| Git diff output                        | 600,000 captured characters                                 |
+| Git history                            | 20 local commits                                            |
+| Paths in one Git stage request         | 200                                                         |
+| Git commit message                     | 4,000 characters                                            |
 | Agent loop, every provider route       | 48 rounds by default, configured by `WORK_MAX_AGENT_ROUNDS` |
 | Tool-call safety budget                | `max(128, configured rounds × 8)` calls                     |
 
@@ -766,6 +896,13 @@ current database role to be `admin`.
 | `GET`    | `/tasks/:id/files`                  | List a workspace directory                     |
 | `GET`    | `/tasks/:id/file`                   | Read a workspace text file                     |
 | `PUT`    | `/tasks/:id/file`                   | Save a workspace text file                     |
+| `GET`    | `/tasks/:id/git`                    | Read guarded local Git status and history      |
+| `GET`    | `/tasks/:id/git/diff`               | Read a bounded local diff                      |
+| `POST`   | `/tasks/:id/git/init`               | Initialize local Git                           |
+| `POST`   | `/tasks/:id/git/stage`              | Stage explicit workspace paths                 |
+| `POST`   | `/tasks/:id/git/commit`             | Commit staged changes                          |
+| `POST`   | `/tasks/:id/git/branches`           | Create a local branch                          |
+| `POST`   | `/tasks/:id/git/switch`             | Switch to an existing clean local branch       |
 | `POST`   | `/tasks/:id/preview/start`          | Start the managed preview                      |
 | `POST`   | `/tasks/:id/preview/stop`           | Stop the managed preview                       |
 
@@ -912,6 +1049,11 @@ toggle to enable. Inspect DNS, proxy, firewall, registry, certificate, Docker
 daemon, and upstream service configuration. Also confirm that the selected
 runtime image contains the command being invoked.
 
+The Git tab is local-only and never performs a remote operation. Use the
+Terminal or model command surface only when the task's network and credential
+policy deliberately permits remote Git. Do not paste a long-lived access token
+into a task workspace.
+
 ### A run stops at an agent limit
 
 The model may have exhausted the configured round or derived tool-call safety
@@ -985,6 +1127,10 @@ Before enabling Work for an installation, remember:
 - Current UI-created Work tasks have bridge network egress and no UI network
   switch.
 - Work volumes have no independent disk quota.
+- The Git tab is local-only; remote credentials are never mounted or accepted
+  by its API.
+- Host firewall policy, daemon isolation, outbound restrictions, and real
+  volume quotas remain operator-enforced controls.
 - Remote providers receive requested tool results and can incur multiple calls
   per run.
 - Preview ports stay on backend loopback and are exposed only through signed,

--- a/frontend/e2e/lib/mockApi.ts
+++ b/frontend/e2e/lib/mockApi.ts
@@ -279,6 +279,31 @@ type MockWorkFile = {
   updatedAt?: number;
 };
 
+type MockWorkGitStatus = {
+  initialized: boolean;
+  branch?: string;
+  detached: boolean;
+  head?: string;
+  upstream?: string;
+  ahead: number;
+  behind: number;
+  changes: Array<{
+    path: string;
+    originalPath?: string;
+    indexStatus: string;
+    workingTreeStatus: string;
+    staged: boolean;
+  }>;
+  branches: string[];
+  commits: Array<{
+    hash: string;
+    shortHash: string;
+    author: string;
+    authoredAt: string;
+    subject: string;
+  }>;
+};
+
 type MockWorkRunResult = {
   assistantMessage?: string;
   messages?: MockWorkMessage[];
@@ -336,6 +361,8 @@ type MockOptions = {
   workTaskDetailUpdates?: Record<string, Partial<MockWorkTask>>;
   workFiles?: Record<string, MockWorkFile[]>;
   workFileContents?: Record<string, string>;
+  workGitStatuses?: Record<string, MockWorkGitStatus>;
+  workGitDiffs?: Record<string, string>;
   deferWorkFileUpdates?: boolean;
   workFileUpdateFailure?: string;
   workRunResult?: MockWorkRunResult;
@@ -505,6 +532,8 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
   const workFileContents = {
     ...(options.workFileContents ?? {}),
   };
+  const workGitStatuses = structuredClone(options.workGitStatuses ?? {});
+  const workGitDiffs = { ...(options.workGitDiffs ?? {}) };
   const createPreferences = (
     overrides: Partial<typeof defaultPreferences> | undefined
   ) => ({
@@ -592,6 +621,14 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
     action: 'start' | 'stop';
     command?: string;
   }> = [];
+  const workGitRequests: Array<{
+    taskId: string;
+    action:
+      'status' | 'diff' | 'init' | 'stage' | 'commit' | 'branch' | 'switch';
+    paths?: string[];
+    message?: string;
+    name?: string;
+  }> = [];
   let nextWorkTaskId = workTasks.length + 1;
   let nextWorkMessageId = 1;
 
@@ -658,6 +695,17 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
       hasMoreMessages: page.hasMore,
     };
   };
+
+  const workGitStatus = (taskId: string): MockWorkGitStatus =>
+    (workGitStatuses[taskId] ??= {
+      initialized: false,
+      detached: false,
+      ahead: 0,
+      behind: 0,
+      changes: [],
+      branches: [],
+      commits: [],
+    });
 
   let workTaskTransitionApplied = false;
   const applyWorkTaskTransition = () => {
@@ -1271,6 +1319,112 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
         }
       }
 
+      const workGitDiffMatch = path.match(
+        /^\/work\/tasks\/([^/]+)\/git\/diff$/
+      );
+      if (workGitDiffMatch && method === 'GET') {
+        const taskId = decodeURIComponent(workGitDiffMatch[1]);
+        if (!workTasks.some(item => item.id === taskId)) {
+          await fulfillApiError(route, 404, 'Work task not found');
+          return;
+        }
+        const filePath = url.searchParams.get('path') || undefined;
+        workGitRequests.push({ taskId, action: 'diff' });
+        await fulfillJson(route, {
+          ...(filePath ? { path: filePath } : {}),
+          patch:
+            workGitDiffs[`${taskId}:${filePath || ''}`] ||
+            (filePath
+              ? `diff --git a/${filePath} b/${filePath}\n+mock change\n`
+              : ''),
+          truncated: false,
+        });
+        return;
+      }
+
+      const workGitStatusMatch = path.match(/^\/work\/tasks\/([^/]+)\/git$/);
+      if (workGitStatusMatch && method === 'GET') {
+        const taskId = decodeURIComponent(workGitStatusMatch[1]);
+        if (!workTasks.some(item => item.id === taskId)) {
+          await fulfillApiError(route, 404, 'Work task not found');
+          return;
+        }
+        workGitRequests.push({ taskId, action: 'status' });
+        await fulfillJson(route, workGitStatus(taskId));
+        return;
+      }
+
+      const workGitMutationMatch = path.match(
+        /^\/work\/tasks\/([^/]+)\/git\/(init|stage|commit|branches|switch)$/
+      );
+      if (workGitMutationMatch && method === 'POST') {
+        const taskId = decodeURIComponent(workGitMutationMatch[1]);
+        if (!workTasks.some(item => item.id === taskId)) {
+          await fulfillApiError(route, 404, 'Work task not found');
+          return;
+        }
+        const action = workGitMutationMatch[2];
+        const request = (route.request().postDataJSON() || {}) as {
+          paths?: string[];
+          message?: string;
+          name?: string;
+        };
+        const status = workGitStatus(taskId);
+
+        if (action === 'init') {
+          workGitRequests.push({ taskId, action: 'init' });
+          Object.assign(status, {
+            initialized: true,
+            branch: 'main',
+            detached: false,
+            branches: ['main'],
+          });
+        } else if (action === 'stage') {
+          const paths = request.paths ?? [];
+          workGitRequests.push({ taskId, action: 'stage', paths });
+          status.changes = status.changes.map(change =>
+            paths.includes(change.path)
+              ? {
+                  ...change,
+                  indexStatus:
+                    change.indexStatus === '?'
+                      ? 'A'
+                      : change.workingTreeStatus === '.'
+                        ? change.indexStatus
+                        : change.workingTreeStatus,
+                  workingTreeStatus: '.',
+                  staged: true,
+                }
+              : change
+          );
+        } else if (action === 'commit') {
+          const message = request.message || 'Mock commit';
+          workGitRequests.push({ taskId, action: 'commit', message });
+          const hash = `mock${Date.now()}`;
+          status.head = hash;
+          status.commits.unshift({
+            hash,
+            shortHash: hash.slice(0, 7),
+            author: 'E2E User',
+            authoredAt: new Date().toISOString(),
+            subject: message,
+          });
+          status.changes = status.changes.filter(change => !change.staged);
+        } else if (action === 'branches') {
+          const name = request.name || 'new-branch';
+          workGitRequests.push({ taskId, action: 'branch', name });
+          if (!status.branches.includes(name)) status.branches.push(name);
+        } else {
+          const name = request.name || status.branch || 'main';
+          workGitRequests.push({ taskId, action: 'switch', name });
+          status.branch = name;
+          status.detached = false;
+        }
+
+        await fulfillJson(route, status);
+        return;
+      }
+
       const workPreviewMatch = path.match(
         /^\/work\/tasks\/([^/]+)\/preview\/(start|stop)$/
       );
@@ -1670,5 +1824,6 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
         .forEach(releaseWorkFileUpdate => releaseWorkFileUpdate());
     },
     workPreviewRequests,
+    workGitRequests,
   };
 }

--- a/frontend/e2e/work-pane.spec.ts
+++ b/frontend/e2e/work-pane.spec.ts
@@ -2610,3 +2610,90 @@ test('the terminal explains when a deployment cannot offer it', async ({
     0
   );
 });
+
+test('manages local workspace Git without exposing remote credentials', async ({
+  page,
+}) => {
+  const gitTask = task(
+    'git-workspace',
+    'Git workspace',
+    'The local repository is ready.'
+  );
+  const mock = await mockLibreWebUiApi(page, {
+    workTasks: [gitTask],
+    workGitStatuses: {
+      'git-workspace': {
+        initialized: true,
+        branch: 'main',
+        detached: false,
+        head: 'abc123456789',
+        ahead: 0,
+        behind: 0,
+        changes: [
+          {
+            path: 'src/app.ts',
+            indexStatus: '.',
+            workingTreeStatus: 'M',
+            staged: false,
+          },
+        ],
+        branches: ['main'],
+        commits: [
+          {
+            hash: 'abc123456789',
+            shortHash: 'abc1234',
+            author: 'Robin',
+            authoredAt: '2026-08-02T12:00:00.000Z',
+            subject: 'Initial workspace',
+          },
+        ],
+      },
+    },
+    workGitDiffs: {
+      'git-workspace:src/app.ts':
+        'diff --git a/src/app.ts b/src/app.ts\n+export const ready = true;\n',
+    },
+  });
+
+  await page.goto('/work/git-workspace');
+  await page.getByTestId('work-git-tab').click();
+
+  await expect(page.getByTestId('work-git-panel')).toBeVisible();
+  await expect(page.getByText('Initial workspace')).toBeVisible();
+  await expect(page.getByText(/Local Git only/)).toBeVisible();
+  await expect(page.getByRole('button', { name: /push/i })).toHaveCount(0);
+
+  await page.getByTestId('work-git-change').click();
+  await expect(page.getByTestId('work-git-diff')).toContainText(
+    'export const ready = true;'
+  );
+
+  await page.getByRole('checkbox', { name: 'Select src/app.ts' }).check();
+  await page.getByTestId('work-git-stage-button').click();
+  await expect(page.getByTestId('work-git-commit-button')).toBeDisabled();
+  await page.getByTestId('work-git-commit-input').fill('Save app changes');
+  await expect(page.getByTestId('work-git-commit-button')).toBeEnabled();
+  await page.getByTestId('work-git-commit-button').click();
+  await expect(page.getByText('Save app changes')).toBeVisible();
+
+  await page.getByTestId('work-git-branch-input').fill('feature/local-ui');
+  await page.getByTestId('work-git-create-branch-button').click();
+  await expect(
+    page
+      .getByTestId('work-git-branch-select')
+      .locator('option[value="feature/local-ui"]')
+  ).toHaveCount(1);
+  await page
+    .getByTestId('work-git-branch-select')
+    .selectOption('feature/local-ui');
+
+  await expect
+    .poll(() => mock.workGitRequests.map(request => request.action))
+    .toEqual(['status', 'diff', 'stage', 'commit', 'branch', 'switch']);
+  expect(
+    mock.workGitRequests.find(request => request.action === 'stage')
+  ).toMatchObject({ paths: ['src/app.ts'] });
+  expect(
+    mock.workGitRequests.find(request => request.action === 'commit')
+  ).toMatchObject({ message: 'Save app changes' });
+});

--- a/frontend/src/components/work/WorkspaceGitPanel.tsx
+++ b/frontend/src/components/work/WorkspaceGitPanel.tsx
@@ -1,0 +1,559 @@
+/*
+ * Libre WebUI
+ * Copyright (C) 2025 Kroonen AI, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Check,
+  FileDiff,
+  GitBranch,
+  History,
+  Loader2,
+  Plus,
+  RefreshCw,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui';
+import type { ApiResponse } from '@/types';
+import type { WorkGitDiff, WorkGitStatus } from '@/types/work';
+import { cn } from '@/utils';
+import { workApi } from '@/utils/api/workApi';
+
+interface WorkspaceGitPanelProps {
+  taskId: string;
+  mutationsDisabled?: boolean;
+  disabledReason?: string;
+}
+
+const responseData = <T,>(response: ApiResponse<T>, fallback: string): T => {
+  if (response.success && response.data) return response.data;
+  throw new Error(response.error || fallback);
+};
+
+const errorMessage = (error: unknown, fallback: string): string => {
+  const responseError = (error as { response?: { data?: { error?: unknown } } })
+    ?.response?.data?.error;
+  if (typeof responseError === 'string' && responseError) return responseError;
+  return error instanceof Error && error.message ? error.message : fallback;
+};
+
+export function WorkspaceGitPanel({
+  taskId,
+  mutationsDisabled = false,
+  disabledReason,
+}: WorkspaceGitPanelProps) {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<WorkGitStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
+  const [commitMessage, setCommitMessage] = useState('');
+  const [branchName, setBranchName] = useState('');
+  const [diff, setDiff] = useState<WorkGitDiff | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const generation = useRef(0);
+
+  const loadStatus = useCallback(async () => {
+    const request = ++generation.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const next = responseData(
+        await workApi.getGitStatus(taskId),
+        t('work.git.loadFailed', {
+          defaultValue: 'Could not load Git status.',
+        })
+      );
+      if (request !== generation.current) return;
+      setStatus(next);
+      setSelectedPaths([]);
+    } catch (requestError) {
+      if (request !== generation.current) return;
+      setError(
+        errorMessage(
+          requestError,
+          t('work.git.loadFailed', {
+            defaultValue: 'Could not load Git status.',
+          })
+        )
+      );
+    } finally {
+      if (request === generation.current) setLoading(false);
+    }
+  }, [t, taskId]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void loadStatus(), 0);
+    return () => {
+      window.clearTimeout(timer);
+      generation.current += 1;
+    };
+  }, [loadStatus]);
+
+  const runMutation = async (
+    action: () => Promise<ApiResponse<WorkGitStatus>>,
+    successMessage: string
+  ): Promise<boolean> => {
+    if (mutationsDisabled || busy) return false;
+    setBusy(true);
+    setError(null);
+    try {
+      const next = responseData(
+        await action(),
+        t('work.git.actionFailed', { defaultValue: 'Git action failed.' })
+      );
+      setStatus(next);
+      setSelectedPaths([]);
+      setDiff(null);
+      toast.success(successMessage);
+      return true;
+    } catch (actionError) {
+      const message = errorMessage(
+        actionError,
+        t('work.git.actionFailed', { defaultValue: 'Git action failed.' })
+      );
+      setError(message);
+      toast.error(message);
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const openDiff = async (path: string) => {
+    setDiffLoading(true);
+    setError(null);
+    try {
+      setDiff(
+        responseData(
+          await workApi.getGitDiff(taskId, path),
+          t('work.git.diffFailed', {
+            defaultValue: 'Could not load this diff.',
+          })
+        )
+      );
+    } catch (diffError) {
+      setError(
+        errorMessage(
+          diffError,
+          t('work.git.diffFailed', {
+            defaultValue: 'Could not load this diff.',
+          })
+        )
+      );
+    } finally {
+      setDiffLoading(false);
+    }
+  };
+
+  if (loading && !status) {
+    return (
+      <div className='flex h-full items-center justify-center text-ink-muted'>
+        <Loader2 className='h-5 w-5 animate-spin' />
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className='flex h-full flex-col items-center justify-center px-6 text-center'>
+        <GitBranch className='mb-3 h-8 w-8 text-error-500' />
+        <p className='max-w-sm text-xs leading-relaxed text-error-600'>
+          {error ||
+            t('work.git.loadFailed', {
+              defaultValue: 'Could not load Git status.',
+            })}
+        </p>
+        <Button
+          size='sm'
+          variant='secondary'
+          className='mt-4'
+          onClick={() => void loadStatus()}
+        >
+          <RefreshCw className='h-3.5 w-3.5' />
+          {t('common.retry', { defaultValue: 'Retry' })}
+        </Button>
+      </div>
+    );
+  }
+
+  if (!status.initialized) {
+    return (
+      <div className='flex h-full flex-col items-center justify-center px-6 text-center'>
+        <GitBranch className='mb-3 h-8 w-8 text-ink-subtle' />
+        <h3 className='text-sm font-medium text-ink'>
+          {t('work.git.notInitialized', {
+            defaultValue: 'Git is not initialized',
+          })}
+        </h3>
+        <p className='mt-1 max-w-sm text-xs leading-relaxed text-ink-muted'>
+          {t('work.git.initializeDescription', {
+            defaultValue:
+              'Create a local repository for status, diffs, branches, and commits. No remote credentials are connected.',
+          })}
+        </p>
+        {error && <p className='mt-3 text-xs text-error-600'>{error}</p>}
+        <Button
+          data-testid='work-git-init-button'
+          size='sm'
+          className='mt-4 bg-[#ff7b52] text-[#3d120c] hover:bg-[#ff7b52]/90'
+          disabled={mutationsDisabled || busy}
+          onClick={() =>
+            void runMutation(
+              () => workApi.initializeGit(taskId),
+              t('work.git.initialized', {
+                defaultValue: 'Git repository initialized.',
+              })
+            )
+          }
+        >
+          {busy ? (
+            <Loader2 className='me-2 h-3.5 w-3.5 animate-spin' />
+          ) : (
+            <Plus className='me-2 h-3.5 w-3.5' />
+          )}
+          {t('work.git.initialize', { defaultValue: 'Initialize Git' })}
+        </Button>
+        {mutationsDisabled && disabledReason && (
+          <p className='mt-2 text-[11px] text-ink-subtle'>{disabledReason}</p>
+        )}
+      </div>
+    );
+  }
+
+  const stagedCount = status.changes.filter(change => change.staged).length;
+  const dirty = status.changes.length > 0;
+
+  return (
+    <div className='flex h-full min-h-0 flex-col' data-testid='work-git-panel'>
+      <div className='flex flex-wrap items-center gap-2 border-b border-line px-3 py-2'>
+        <span className='inline-flex min-w-0 items-center gap-1.5 rounded-lg bg-surface-subtle px-2 py-1 font-mono text-[11px] text-ink'>
+          <GitBranch className='h-3.5 w-3.5 shrink-0' />
+          <span className='truncate'>
+            {status.detached
+              ? t('work.git.detached', { defaultValue: 'detached HEAD' })
+              : status.branch || 'main'}
+          </span>
+        </span>
+        {(status.ahead > 0 || status.behind > 0) && (
+          <span className='text-[10px] text-ink-muted'>
+            ↑{status.ahead} ↓{status.behind}
+          </span>
+        )}
+        <select
+          data-testid='work-git-branch-select'
+          aria-label={t('work.git.switchBranch', {
+            defaultValue: 'Switch local branch',
+          })}
+          value={status.branch || ''}
+          disabled={mutationsDisabled || busy || dirty}
+          onChange={event => {
+            const name = event.target.value;
+            if (!name || name === status.branch) return;
+            void runMutation(
+              () => workApi.switchGitBranch(taskId, name),
+              t('work.git.branchSwitched', {
+                name,
+                defaultValue: 'Switched to {{name}}.',
+              })
+            );
+          }}
+          className='h-7 max-w-44 rounded-lg border border-line bg-surface px-2 text-[11px] text-ink outline-none disabled:opacity-50'
+        >
+          {status.detached && (
+            <option value='' disabled>
+              {t('work.git.detached', { defaultValue: 'detached HEAD' })}
+            </option>
+          )}
+          {status.branches.map(branch => (
+            <option key={branch} value={branch}>
+              {branch}
+            </option>
+          ))}
+        </select>
+        <div className='flex min-w-44 flex-1 items-center gap-1'>
+          <input
+            data-testid='work-git-branch-input'
+            value={branchName}
+            maxLength={200}
+            onChange={event => setBranchName(event.target.value)}
+            placeholder={t('work.git.newBranch', {
+              defaultValue: 'New local branch',
+            })}
+            className='h-7 min-w-0 flex-1 rounded-lg border border-line bg-surface px-2 font-mono text-[11px] text-ink outline-none placeholder:text-ink-subtle focus:border-primary-500'
+          />
+          <Button
+            data-testid='work-git-create-branch-button'
+            size='sm'
+            variant='ghost'
+            className='h-7 px-2'
+            disabled={
+              mutationsDisabled || busy || !status.head || !branchName.trim()
+            }
+            onClick={() => {
+              const name = branchName.trim();
+              void runMutation(
+                () => workApi.createGitBranch(taskId, name),
+                t('work.git.branchCreated', {
+                  name,
+                  defaultValue: 'Created {{name}}.',
+                })
+              ).then(success => {
+                if (success) setBranchName('');
+              });
+            }}
+          >
+            <Plus className='h-3.5 w-3.5' />
+            <span className='hidden sm:inline'>
+              {t('work.git.createBranch', { defaultValue: 'Create' })}
+            </span>
+          </Button>
+        </div>
+        <button
+          type='button'
+          onClick={() => void loadStatus()}
+          disabled={loading || busy}
+          aria-label={t('common.refresh', { defaultValue: 'Refresh' })}
+          className='inline-flex h-7 w-7 items-center justify-center rounded-lg text-ink-muted hover:bg-surface-subtle hover:text-ink disabled:opacity-50'
+        >
+          <RefreshCw className={cn('h-3.5 w-3.5', loading && 'animate-spin')} />
+        </button>
+      </div>
+
+      {error && (
+        <div className='border-b border-error-200 bg-error-50 px-3 py-2 text-xs text-error-700 dark:border-error-900/60 dark:bg-error-900/30 dark:text-error-300'>
+          {error}
+        </div>
+      )}
+      {mutationsDisabled && disabledReason && (
+        <div className='border-b border-line px-3 py-1.5 text-[11px] text-ink-subtle'>
+          {disabledReason}
+        </div>
+      )}
+
+      <div className='grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(14rem,0.8fr)_minmax(18rem,1.2fr)_minmax(13rem,0.8fr)]'>
+        <section className='flex min-h-0 flex-col border-b border-line lg:border-b-0 lg:border-e'>
+          <div className='flex items-center justify-between px-3 py-2'>
+            <h3 className='text-xs font-medium text-ink'>
+              {t('work.git.changes', { defaultValue: 'Changes' })}{' '}
+              <span className='text-ink-subtle'>{status.changes.length}</span>
+            </h3>
+            <Button
+              data-testid='work-git-stage-button'
+              size='sm'
+              variant='ghost'
+              className='h-7 px-2 text-[11px]'
+              disabled={
+                mutationsDisabled ||
+                busy ||
+                (selectedPaths.length === 0 && status.changes.length === 0)
+              }
+              onClick={() => {
+                const paths =
+                  selectedPaths.length > 0
+                    ? selectedPaths
+                    : status.changes.map(change => change.path);
+                void runMutation(
+                  () => workApi.stageGitPaths(taskId, paths),
+                  t('work.git.staged', { defaultValue: 'Changes staged.' })
+                );
+              }}
+            >
+              <Check className='h-3.5 w-3.5' />
+              {selectedPaths.length > 0
+                ? t('work.git.stageSelected', {
+                    count: selectedPaths.length,
+                    defaultValue: 'Stage {{count}}',
+                  })
+                : t('work.git.stageAll', { defaultValue: 'Stage all' })}
+            </Button>
+          </div>
+          <div className='min-h-32 flex-1 overflow-y-auto px-2 pb-2'>
+            {status.changes.length === 0 ? (
+              <p className='px-2 py-8 text-center text-xs text-ink-muted'>
+                {t('work.git.clean', {
+                  defaultValue: 'Working tree is clean.',
+                })}
+              </p>
+            ) : (
+              status.changes.map(change => (
+                <div
+                  key={`${change.path}:${change.originalPath || ''}`}
+                  className='flex items-center gap-1 rounded-lg hover:bg-surface-subtle'
+                >
+                  <input
+                    type='checkbox'
+                    aria-label={t('work.git.selectPath', {
+                      path: change.path,
+                      defaultValue: 'Select {{path}}',
+                    })}
+                    checked={selectedPaths.includes(change.path)}
+                    onChange={event =>
+                      setSelectedPaths(current =>
+                        event.target.checked
+                          ? [...current, change.path]
+                          : current.filter(path => path !== change.path)
+                      )
+                    }
+                    className='ms-2 h-3.5 w-3.5 accent-[#ff7b52]'
+                  />
+                  <button
+                    type='button'
+                    data-testid='work-git-change'
+                    onClick={() => void openDiff(change.path)}
+                    className='flex min-w-0 flex-1 items-center gap-2 px-1.5 py-2 text-start'
+                  >
+                    <span
+                      dir='ltr'
+                      className={cn(
+                        'w-5 shrink-0 font-mono text-[10px] font-semibold',
+                        change.staged ? 'text-emerald-600' : 'text-amber-600'
+                      )}
+                    >
+                      {change.indexStatus}
+                      {change.workingTreeStatus}
+                    </span>
+                    <span
+                      dir='ltr'
+                      className='min-w-0 flex-1 truncate font-mono text-[11px] text-ink'
+                      title={change.path}
+                    >
+                      {change.path}
+                    </span>
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+          <div className='border-t border-line p-2'>
+            <textarea
+              data-testid='work-git-commit-input'
+              value={commitMessage}
+              maxLength={4000}
+              rows={2}
+              onChange={event => setCommitMessage(event.target.value)}
+              placeholder={t('work.git.commitMessage', {
+                defaultValue: 'Commit message',
+              })}
+              className='w-full resize-none rounded-lg border border-line bg-surface px-2.5 py-2 text-xs text-ink outline-none placeholder:text-ink-subtle focus:border-primary-500'
+            />
+            <Button
+              data-testid='work-git-commit-button'
+              size='sm'
+              className='mt-1.5 w-full bg-[#ff7b52] text-[#3d120c] hover:bg-[#ff7b52]/90'
+              disabled={
+                mutationsDisabled ||
+                busy ||
+                stagedCount === 0 ||
+                !commitMessage.trim()
+              }
+              onClick={() => {
+                const message = commitMessage.trim();
+                void runMutation(
+                  () => workApi.commitGit(taskId, message),
+                  t('work.git.committed', {
+                    defaultValue: 'Commit created.',
+                  })
+                ).then(success => {
+                  if (success) setCommitMessage('');
+                });
+              }}
+            >
+              {busy && <Loader2 className='h-3.5 w-3.5 animate-spin' />}
+              {t('work.git.commit', { defaultValue: 'Commit staged changes' })}
+            </Button>
+          </div>
+        </section>
+
+        <section className='flex min-h-48 min-w-0 flex-col border-b border-line lg:border-b-0 lg:border-e'>
+          <div className='flex items-center gap-2 px-3 py-2 text-xs font-medium text-ink'>
+            <FileDiff className='h-3.5 w-3.5' />
+            {diff?.path || t('work.git.diff', { defaultValue: 'Diff preview' })}
+          </div>
+          {diffLoading ? (
+            <Loader2 className='m-auto h-5 w-5 animate-spin text-ink-muted' />
+          ) : diff ? (
+            diff.patch ? (
+              <pre
+                data-testid='work-git-diff'
+                dir='ltr'
+                className='min-h-0 flex-1 overflow-auto whitespace-pre p-3 text-left font-mono text-[11px] leading-relaxed text-ink'
+              >
+                {diff.patch}
+                {diff.truncated && '\n… diff truncated …'}
+              </pre>
+            ) : (
+              <p className='m-auto px-5 text-center text-xs text-ink-muted'>
+                {t('work.git.noDiff', {
+                  defaultValue:
+                    'No textual diff is available yet. Untracked files appear after staging.',
+                })}
+              </p>
+            )
+          ) : (
+            <p className='m-auto px-5 text-center text-xs text-ink-muted'>
+              {t('work.git.selectChange', {
+                defaultValue: 'Select a changed file to inspect its diff.',
+              })}
+            </p>
+          )}
+        </section>
+
+        <section className='min-h-36 overflow-y-auto p-3'>
+          <div className='mb-2 flex items-center gap-2 text-xs font-medium text-ink'>
+            <History className='h-3.5 w-3.5' />
+            {t('work.git.history', { defaultValue: 'Local history' })}
+          </div>
+          {status.commits.length === 0 ? (
+            <p className='py-6 text-center text-xs text-ink-muted'>
+              {t('work.git.noCommits', { defaultValue: 'No commits yet.' })}
+            </p>
+          ) : (
+            <ol className='space-y-2'>
+              {status.commits.map(commit => (
+                <li
+                  key={commit.hash}
+                  className='rounded-lg border border-line bg-surface px-2.5 py-2'
+                >
+                  <p dir='auto' className='text-xs text-ink'>
+                    {commit.subject}
+                  </p>
+                  <p className='mt-1 flex flex-wrap gap-x-2 text-[10px] text-ink-subtle'>
+                    <span dir='ltr' className='font-mono'>
+                      {commit.shortHash}
+                    </span>
+                    <span dir='auto'>{commit.author}</span>
+                    <time dateTime={commit.authoredAt}>
+                      {new Date(commit.authoredAt).toLocaleDateString()}
+                    </time>
+                  </p>
+                </li>
+              ))}
+            </ol>
+          )}
+          <p className='mt-4 border-t border-line pt-3 text-[10px] leading-relaxed text-ink-subtle'>
+            {t('work.git.localOnly', {
+              defaultValue:
+                'Local Git only. Push, pull, and pull requests require a separate trusted credential broker.',
+            })}
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/work/WorkspacePane.tsx
+++ b/frontend/src/components/work/WorkspacePane.tsx
@@ -22,6 +22,7 @@ import {
   File,
   Files as FilesIcon,
   Folder,
+  GitBranch,
   GitCompareArrows,
   Loader2,
   Monitor,
@@ -45,6 +46,7 @@ import { Button } from '@/components/ui';
 import { WorkLiveRunSurface } from '@/components/work/WorkLiveRunSurface';
 import { WorkspaceCodeEditor } from '@/components/work/WorkspaceCodeEditor';
 import { WorkspaceDiffView } from '@/components/work/WorkspaceDiffView';
+import { WorkspaceGitPanel } from '@/components/work/WorkspaceGitPanel';
 import { WorkspaceTerminal } from '@/components/work/WorkspaceTerminal';
 import { isRTL } from '@/i18n';
 import type {
@@ -69,7 +71,7 @@ import {
 } from '@/utils/workCode';
 import { diffWorkLines, workDiffStats } from '@/utils/workDiff';
 
-type WorkspaceTab = 'files' | 'activity' | 'terminal' | 'preview';
+type WorkspaceTab = 'files' | 'activity' | 'git' | 'terminal' | 'preview';
 
 interface WorkspacePaneProps {
   task: WorkTask;
@@ -463,6 +465,12 @@ export function WorkspacePane({
       testId: 'work-activity-tab',
     },
     {
+      id: 'git',
+      label: t('work.workspace.git', { defaultValue: 'Git' }),
+      icon: GitBranch,
+      testId: 'work-git-tab',
+    },
+    {
       id: 'terminal',
       label: t('work.workspace.terminal', { defaultValue: 'Terminal' }),
       icon: TerminalSquare,
@@ -716,7 +724,9 @@ export function WorkspacePane({
           </>
         )}
 
-        {tab === 'activity' && <div className='min-w-0 flex-1' />}
+        {(tab === 'activity' || tab === 'git') && (
+          <div className='min-w-0 flex-1' />
+        )}
 
         {tab === 'terminal' && (
           <div className='flex min-w-0 flex-1 items-center gap-2'>
@@ -998,6 +1008,38 @@ export function WorkspacePane({
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {tab === 'git' && (
+        <div
+          id='work-workspace-panel-git'
+          role='tabpanel'
+          aria-labelledby='work-workspace-tab-git'
+          className='min-h-0 flex-1'
+        >
+          <WorkspaceGitPanel
+            taskId={task.id}
+            mutationsDisabled={
+              taskActive ||
+              task.previewStatus === 'starting' ||
+              task.previewStatus === 'running'
+            }
+            disabledReason={
+              taskActive
+                ? t('work.git.blockedByRun', {
+                    defaultValue:
+                      'Git write actions unlock when the model turn finishes.',
+                  })
+                : task.previewStatus === 'starting' ||
+                    task.previewStatus === 'running'
+                  ? t('work.git.blockedByPreview', {
+                      defaultValue:
+                        'Stop the preview before changing Git state.',
+                    })
+                  : undefined
+            }
+          />
         </div>
       )}
 

--- a/frontend/src/types/work.ts
+++ b/frontend/src/types/work.ts
@@ -241,6 +241,41 @@ export interface WorkFile {
   updatedAt?: number;
 }
 
+export interface WorkGitChange {
+  path: string;
+  originalPath?: string;
+  indexStatus: string;
+  workingTreeStatus: string;
+  staged: boolean;
+}
+
+export interface WorkGitCommit {
+  hash: string;
+  shortHash: string;
+  author: string;
+  authoredAt: string;
+  subject: string;
+}
+
+export interface WorkGitStatus {
+  initialized: boolean;
+  branch?: string;
+  detached: boolean;
+  head?: string;
+  upstream?: string;
+  ahead: number;
+  behind: number;
+  changes: WorkGitChange[];
+  branches: string[];
+  commits: WorkGitCommit[];
+}
+
+export interface WorkGitDiff {
+  path?: string;
+  patch: string;
+  truncated: boolean;
+}
+
 export interface CreateWorkTaskRequest {
   message: string;
   model: string;

--- a/frontend/src/utils/api/workApi.ts
+++ b/frontend/src/utils/api/workApi.ts
@@ -23,6 +23,8 @@ import type {
   WorkCapabilities,
   WorkFile,
   WorkFileEntry,
+  WorkGitDiff,
+  WorkGitStatus,
   WorkMessagePage,
   WorkTask,
   WorkTaskSummary,
@@ -120,6 +122,54 @@ export const workApi = {
         { content, expectedUpdatedAt },
         { params: { path } }
       )
+      .then(response => response.data),
+
+  getGitStatus: (taskId: string): Promise<ApiResponse<WorkGitStatus>> =>
+    api.get(`${taskPath(taskId)}/git`).then(response => response.data),
+
+  getGitDiff: (
+    taskId: string,
+    path?: string
+  ): Promise<ApiResponse<WorkGitDiff>> =>
+    api
+      .get(`${taskPath(taskId)}/git/diff`, {
+        params: path ? { path } : undefined,
+      })
+      .then(response => response.data),
+
+  initializeGit: (taskId: string): Promise<ApiResponse<WorkGitStatus>> =>
+    api.post(`${taskPath(taskId)}/git/init`).then(response => response.data),
+
+  stageGitPaths: (
+    taskId: string,
+    paths: string[]
+  ): Promise<ApiResponse<WorkGitStatus>> =>
+    api
+      .post(`${taskPath(taskId)}/git/stage`, { paths })
+      .then(response => response.data),
+
+  commitGit: (
+    taskId: string,
+    message: string
+  ): Promise<ApiResponse<WorkGitStatus>> =>
+    api
+      .post(`${taskPath(taskId)}/git/commit`, { message })
+      .then(response => response.data),
+
+  createGitBranch: (
+    taskId: string,
+    name: string
+  ): Promise<ApiResponse<WorkGitStatus>> =>
+    api
+      .post(`${taskPath(taskId)}/git/branches`, { name })
+      .then(response => response.data),
+
+  switchGitBranch: (
+    taskId: string,
+    name: string
+  ): Promise<ApiResponse<WorkGitStatus>> =>
+    api
+      .post(`${taskPath(taskId)}/git/switch`, { name })
       .then(response => response.data),
 
   startPreview: (

--- a/scripts/test-work-runtime.mjs
+++ b/scripts/test-work-runtime.mjs
@@ -22,6 +22,10 @@ const runtimeModule = await import(
     path.join(repoRoot, 'backend', 'dist', 'services', 'workRuntimeService.js')
   ).href
 );
+const gitModule = await import(
+  pathToFileURL(path.join(repoRoot, 'backend', 'dist', 'utils', 'workGit.js'))
+    .href
+);
 
 const {
   PREVIEW_TARGET_SCRIPT,
@@ -36,6 +40,13 @@ const {
   parsePublishedPort,
   validateWorkspacePath,
 } = runtimeModule;
+const {
+  buildWorkGitCommand,
+  parseWorkGitLog,
+  parseWorkGitStatus,
+  validateWorkGitBranchName,
+  validateWorkGitRepositoryPaths,
+} = gitModule;
 
 const detectPreview = workspace =>
   JSON.parse(
@@ -85,6 +96,103 @@ const optionValues = (args, option) =>
   args.flatMap((value, index) =>
     value === option && index + 1 < args.length ? [args[index + 1]] : []
   );
+
+test('Work Git commands disable ambient config, prompts, hooks, and protocols', () => {
+  const command = buildWorkGitCommand(['status', '--short']);
+  assert.equal(command[0], 'env');
+  assert.ok(command.includes('GIT_CONFIG_NOSYSTEM=1'));
+  assert.ok(command.includes('GIT_CONFIG_GLOBAL=/dev/null'));
+  assert.ok(command.includes('GIT_TERMINAL_PROMPT=0'));
+  assert.ok(command.includes('core.hooksPath=/dev/null'));
+  assert.ok(command.includes('credential.helper='));
+  assert.ok(command.includes('protocol.allow=never'));
+  assert.deepEqual(command.slice(-2), ['status', '--short']);
+});
+
+test('Work Git repository metadata must remain inside /workspace', () => {
+  assert.doesNotThrow(() =>
+    validateWorkGitRepositoryPaths(
+      '/workspace\n/workspace/.git\n/workspace/.git\n'
+    )
+  );
+  assert.throws(
+    () =>
+      validateWorkGitRepositoryPaths(
+        '/workspace\n/tmp/borrowed.git\n/tmp/borrowed.git\n'
+      ),
+    /metadata must stay inside/
+  );
+  assert.throws(
+    () =>
+      validateWorkGitRepositoryPaths(
+        '/workspace/project\n/workspace/.git\n/workspace/.git\n'
+      ),
+    /exactly \/workspace/
+  );
+});
+
+test('Work Git parses porcelain status and bounded history without a shell', () => {
+  const status = parseWorkGitStatus(
+    [
+      '# branch.oid abcdef123456',
+      '# branch.head main',
+      '# branch.upstream origin/main',
+      '# branch.ab +2 -1',
+      '1 M. N... 100644 100644 100644 aaaaaa bbbbbb staged.txt',
+      '2 R. N... 100644 100644 100644 aaaaaa bbbbbb R100 renamed file.txt',
+      'old file.txt',
+      '? new file.txt',
+      '',
+    ].join('\0')
+  );
+  assert.equal(status.branch, 'main');
+  assert.equal(status.ahead, 2);
+  assert.equal(status.behind, 1);
+  assert.deepEqual(
+    status.changes.map(change => ({
+      path: change.path,
+      originalPath: change.originalPath,
+      staged: change.staged,
+    })),
+    [
+      { path: 'new file.txt', originalPath: undefined, staged: false },
+      {
+        path: 'renamed file.txt',
+        originalPath: 'old file.txt',
+        staged: true,
+      },
+      { path: 'staged.txt', originalPath: undefined, staged: true },
+    ]
+  );
+
+  assert.deepEqual(
+    parseWorkGitLog(
+      [
+        'abcdef',
+        'abc123',
+        'Robin',
+        '2026-08-02T12:00:00Z',
+        'Safe commit',
+        '',
+      ].join('\0')
+    ),
+    [
+      {
+        hash: 'abcdef',
+        shortHash: 'abc123',
+        author: 'Robin',
+        authoredAt: '2026-08-02T12:00:00Z',
+        subject: 'Safe commit',
+      },
+    ]
+  );
+});
+
+test('Work Git rejects branch names that can be parsed as options', () => {
+  assert.equal(validateWorkGitBranchName('feature/git-ui'), 'feature/git-ui');
+  assert.throws(() => validateWorkGitBranchName('-force'), /invalid/);
+  assert.throws(() => validateWorkGitBranchName('bad\nbranch'), /invalid/);
+});
 
 test('Work runtime defaults pin the image and bound resource use', () => {
   assert.deepEqual(WORK_RUNTIME_DEFAULTS, {


### PR DESCRIPTION
## Summary

- add an authenticated, administrator-only Git tab for each owned Work task
- support guarded local status/history/diff, explicit path staging, commits, branch creation, and clean-worktree branch switching
- run fixed Git argv arrays inside the task sandbox with ambient config, prompts, hooks, credentials, signing, maintenance, submodule recursion, and protocols disabled
- reject repositories whose worktree or resolved Git metadata escapes `/workspace`, and block executable clean/smudge/process filters before write operations
- block Git mutations while a model run, terminal, or preview owns the container
- reject invalid UTF-8 file reads instead of silently replacing bytes
- document the local-only Git boundary and production hardening for daemon isolation, sandbox-to-host firewalling, egress policy, real storage quotas, and deployed-policy verification

## Security boundary

The UI intentionally has no clone, fetch, pull, push, remote-management, arbitrary Git command, token, SSH-key, or pull-request controls. Remote Git requires a future trusted credential broker, ideally short-lived installation tokens scoped to one repository and action.

Host firewall policy, a dedicated/rootless Docker daemon or VM, and enforceable storage-driver quotas remain operator-owned deployment controls; the docs state this explicitly.

## Validation

- `npm run format:check`
- backend lint and frontend strict lint
- `npm run build`
- `npm run test:package`
- `npm run test:work`
- all 32 tests in `frontend/e2e/work-pane.spec.ts`
- focused hardened `git init` smoke test

Forgejo and GitHub branch heads both resolve to `ebfc48aa5a8a6458e2cb0ed801b3e273902a1f90`.