### PR TITLE
test(e2e): pinned folders and drag-and-drop chat foldering

### DIFF
--- a/frontend/e2e/lib/mockApi.ts
+++ b/frontend/e2e/lib/mockApi.ts
@@ -232,6 +232,15 @@ type MockSession = {
   messages: MockMessage[];
   createdAt: number;
   updatedAt: number;
+  folderId?: string | null;
+  pinned?: boolean;
+};
+
+type MockFolder = {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
 };
 
 type MockChatStream = {
@@ -370,6 +379,7 @@ type MockOptions = {
     preferences?: Partial<typeof defaultPreferences>;
   }>;
   sessions?: MockSession[];
+  folders?: MockFolder[];
   models?: MockModel[];
   ollamaHealthy?: boolean;
   plugins?: MockPlugin[];
@@ -573,6 +583,7 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
   const authRole = options.authRole ?? 'admin';
   const authUsers = options.authUsers ?? [];
   const sessions = structuredClone(options.sessions ?? []);
+  const folders = structuredClone(options.folders ?? []);
   let models = options.models ?? defaultModels;
   const ollamaHealthy = options.ollamaHealthy ?? true;
   const plugins = structuredClone(options.plugins ?? []);
@@ -651,6 +662,9 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
     sessionId: string;
     updates: Partial<MockSession>;
   }> = [];
+  const folderCreateRequests: Array<{ name: string }> = [];
+  const folderRenameRequests: Array<{ folderId: string; name: string }> = [];
+  const folderDeleteRequests: string[] = [];
   const workTaskCreateRequests: Array<{
     message: string;
     model: string;
@@ -696,6 +710,7 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
   }> = [];
   let nextWorkTaskId = workTasks.length + 1;
   let nextWorkMessageId = 1;
+  let nextFolderId = folders.length + 1;
 
   const authUserForRoute = (route: Route) => {
     const authorization = route.request().headers().authorization;
@@ -1824,6 +1839,51 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
         return;
       }
 
+      if (path === '/chat/folders' && method === 'GET') {
+        await fulfillJson(route, folders);
+        return;
+      }
+
+      if (path === '/chat/folders' && method === 'POST') {
+        const request = route.request().postDataJSON() as { name?: string };
+        const now = Date.now();
+        const folder: MockFolder = {
+          id: `folder-${nextFolderId++}`,
+          name: String(request.name ?? '').trim(),
+          createdAt: now,
+          updatedAt: now,
+        };
+        folderCreateRequests.push({ name: folder.name });
+        folders.push(folder);
+        await fulfillJson(route, folder);
+        return;
+      }
+
+      const folderMatch = path.match(/^\/chat\/folders\/([^/]+)$/);
+      if (folderMatch && (method === 'PUT' || method === 'DELETE')) {
+        const folderId = decodeURIComponent(folderMatch[1]);
+        const folder = folders.find(item => item.id === folderId);
+        if (!folder) {
+          await fulfillApiError(route, 404, 'Folder not found');
+          return;
+        }
+        if (method === 'PUT') {
+          const request = route.request().postDataJSON() as { name?: string };
+          folder.name = String(request.name ?? '').trim();
+          folder.updatedAt = Date.now();
+          folderRenameRequests.push({ folderId, name: folder.name });
+          await fulfillJson(route, folder);
+          return;
+        }
+        folderDeleteRequests.push(folderId);
+        folders.splice(folders.indexOf(folder), 1);
+        for (const session of sessions) {
+          if (session.folderId === folderId) session.folderId = null;
+        }
+        await fulfillJson(route, undefined);
+        return;
+      }
+
       const generatedTitleMatch = path.match(
         /^\/chat\/sessions\/([^/]+)\/generate-title$/
       );
@@ -2105,6 +2165,9 @@ export async function mockLibreWebUiApi(page: Page, options: MockOptions = {}) {
     soundGenerationRequests,
     titleGenerationRequests,
     sessionUpdateRequests,
+    folderCreateRequests,
+    folderRenameRequests,
+    folderDeleteRequests,
     workTaskCreateRequests,
     workTaskDetailRequests,
     workTaskListRequests,

--- a/frontend/e2e/sidebar-pinned-folders.spec.ts
+++ b/frontend/e2e/sidebar-pinned-folders.spec.ts
@@ -1,0 +1,229 @@
+/*
+ * Libre WebUI
+ * Copyright (C) 2025 Kroonen AI, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { mockLibreWebUiApi } from './lib/mockApi';
+
+const startOfToday = new Date().setHours(0, 0, 0, 0);
+
+const gardenSession = () => ({
+  id: 'garden-plan',
+  title: 'Garden plan',
+  model: 'llama3.2:3b',
+  messages: [],
+  createdAt: startOfToday + 8 * 3_600_000,
+  updatedAt: startOfToday + 8 * 3_600_000,
+});
+
+const budgetSession = () => ({
+  id: 'budget-review',
+  title: 'Budget review',
+  model: 'llama3.2:3b',
+  messages: [],
+  createdAt: startOfToday + 9 * 3_600_000,
+  updatedAt: startOfToday + 9 * 3_600_000,
+});
+
+const workFolder = () => ({
+  id: 'work-projects',
+  name: 'Work projects',
+  createdAt: startOfToday + 1 * 3_600_000,
+  updatedAt: startOfToday + 1 * 3_600_000,
+});
+
+const scrollRegion = (page: Page) =>
+  page.getByTestId('sidebar-session-scroll-region');
+
+const sessionRow = (page: Page, title: string) =>
+  scrollRegion(page)
+    .locator('div[draggable="true"]')
+    .filter({ hasText: title });
+
+const groupLabel = (page: Page, name: string) =>
+  scrollRegion(page).getByText(name, { exact: true });
+
+const yOf = async (locator: Locator) => (await locator.boundingBox())?.y ?? -1;
+
+// The sidebar files chats with native HTML5 drag and drop, which Playwright's
+// dragTo does not reliably synthesize for React's synthetic handlers. Dispatch
+// real DragEvents with an in-page DataTransfer instead, letting React commit
+// the draggingSessionId set in dragstart before the drop handler reads it.
+const dragSessionTo = async (page: Page, source: Locator, target: Locator) => {
+  await source.evaluate(element => {
+    const dataTransfer = new DataTransfer();
+    element.dispatchEvent(
+      new DragEvent('dragstart', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      })
+    );
+    (
+      window as unknown as {
+        __libreDragDataTransfer?: DataTransfer;
+      }
+    ).__libreDragDataTransfer = dataTransfer;
+  });
+  await page.waitForTimeout(50);
+  await target.evaluate(element => {
+    const dataTransfer = (
+      window as unknown as { __libreDragDataTransfer?: DataTransfer }
+    ).__libreDragDataTransfer;
+    element.dispatchEvent(
+      new DragEvent('dragover', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      })
+    );
+    element.dispatchEvent(
+      new DragEvent('drop', {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer,
+      })
+    );
+  });
+  await page.waitForTimeout(50);
+  await source.evaluate(element => {
+    element.dispatchEvent(new DragEvent('dragend', { bubbles: true }));
+  });
+};
+
+const openActionsFor = async (page: Page, title: string) => {
+  const row = sessionRow(page, title);
+  await row.hover();
+  await row.getByTestId('sidebar-session-actions').click();
+  await expect(page.getByTestId('sidebar-session-menu')).toBeVisible();
+};
+
+test('pinning a chat moves it to the Pinned group and survives a reload', async ({
+  page,
+}) => {
+  const mockApi = await mockLibreWebUiApi(page, {
+    sessions: [gardenSession(), budgetSession()],
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+  await page.goto('/c/garden-plan');
+
+  await expect(sessionRow(page, 'Garden plan')).toBeVisible();
+  await expect(sessionRow(page, 'Budget review')).toBeVisible();
+  await expect(groupLabel(page, 'Pinned')).toHaveCount(0);
+
+  await openActionsFor(page, 'Garden plan');
+  await page.getByRole('menuitem', { name: 'Pin' }).click();
+
+  await expect(groupLabel(page, 'Pinned')).toBeVisible();
+  await expect
+    .poll(async () => {
+      const rowY = await yOf(sessionRow(page, 'Garden plan'));
+      const pinnedY = await yOf(groupLabel(page, 'Pinned'));
+      const todayY = await yOf(groupLabel(page, 'Today'));
+      return rowY > pinnedY && rowY < todayY;
+    })
+    .toBe(true);
+
+  await page.reload();
+
+  await expect(groupLabel(page, 'Pinned')).toBeVisible();
+  await expect
+    .poll(async () => {
+      const rowY = await yOf(sessionRow(page, 'Garden plan'));
+      const pinnedY = await yOf(groupLabel(page, 'Pinned'));
+      const todayY = await yOf(groupLabel(page, 'Today'));
+      return rowY > pinnedY && rowY < todayY;
+    })
+    .toBe(true);
+
+  await openActionsFor(page, 'Garden plan');
+  await page.getByRole('menuitem', { name: 'Unpin' }).click();
+
+  await expect(groupLabel(page, 'Pinned')).toHaveCount(0);
+  await expect
+    .poll(
+      async () =>
+        (await yOf(sessionRow(page, 'Garden plan'))) >
+        (await yOf(groupLabel(page, 'Today')))
+    )
+    .toBe(true);
+
+  expect(mockApi.sessionUpdateRequests.map(request => request.updates)).toEqual(
+    [{ pinned: true }, { pinned: false }]
+  );
+});
+
+test('dragging a chat onto a folder files it and back onto a date group un-files it', async ({
+  page,
+}) => {
+  const mockApi = await mockLibreWebUiApi(page, {
+    sessions: [gardenSession(), budgetSession()],
+    folders: [workFolder()],
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem('i18nextLng', 'en');
+  });
+  await page.goto('/c/garden-plan');
+
+  await expect(groupLabel(page, 'Work projects')).toBeVisible();
+  await expect(sessionRow(page, 'Budget review')).toBeVisible();
+
+  await expect
+    .poll(
+      async () =>
+        (await yOf(sessionRow(page, 'Budget review'))) >
+        (await yOf(groupLabel(page, 'Today')))
+    )
+    .toBe(true);
+
+  await dragSessionTo(
+    page,
+    sessionRow(page, 'Budget review'),
+    groupLabel(page, 'Work projects')
+  );
+
+  await expect
+    .poll(async () => {
+      const rowY = await yOf(sessionRow(page, 'Budget review'));
+      const folderY = await yOf(groupLabel(page, 'Work projects'));
+      const todayY = await yOf(groupLabel(page, 'Today'));
+      return rowY > folderY && rowY < todayY;
+    })
+    .toBe(true);
+  expect(mockApi.sessionUpdateRequests).toContainEqual({
+    sessionId: 'budget-review',
+    updates: { folderId: 'work-projects' },
+  });
+
+  await dragSessionTo(
+    page,
+    sessionRow(page, 'Budget review'),
+    groupLabel(page, 'Today')
+  );
+
+  await expect
+    .poll(
+      async () =>
+        (await yOf(sessionRow(page, 'Budget review'))) >
+        (await yOf(groupLabel(page, 'Today')))
+    )
+    .toBe(true);
+  expect(mockApi.sessionUpdateRequests.at(-1)?.updates).toEqual({
+    folderId: null,
+  });
+});


### PR DESCRIPTION
## Summary

Adds e2e coverage for pinned chats and drag-and-drop chat foldering in the sidebar, plus the mock-API support those tests need.

## Changes

- `frontend/e2e/sidebar-pinned-folders.spec.ts` (new): covers pinning/unpinning a chat from the session action menu, persistence of pinned folders via mocked routes, and dragging a chat onto a folder.
- `frontend/e2e/lib/mockApi.ts`: extends the e2e mock API with `folders`/`folder` routes and the `pinned` flag on mocked sessions.

## Notes

- Mocked `systemInfo` intentionally does not enable agents (the tests never interact with the nav).
- Drag-and-drop uses a manual `dragstart` → `dragover` → `drop` dispatch with an in-page `DataTransfer`, since Playwright's `dragTo` doesn't fire the native HTML5 drag events React's synthetic handlers rely on in headless Chromium.

## Verification

- `playwright test` (both new tests pass)
- pre-commit checks (format, lint, type-check) pass
