### PR TITLE
fix: Resolve CodeQL findings and MinIO CI pulls

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -91,7 +91,7 @@ jobs:
             --publish 9000:9000 \
             --env MINIO_ROOT_USER=libreminio \
             --env MINIO_ROOT_PASSWORD=libre-ci-minio-password \
-            minio/minio:RELEASE.2025-07-23T15-54-02Z server /data
+            quay.io/minio/minio:RELEASE.2025-07-23T15-54-02Z server /data
           for attempt in $(seq 1 30); do
             if curl --fail --silent http://127.0.0.1:9000/minio/health/live >/dev/null; then
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
             --publish 9000:9000 \
             --env MINIO_ROOT_USER=libreminio \
             --env MINIO_ROOT_PASSWORD=libre-ci-minio-password \
-            minio/minio:RELEASE.2025-07-23T15-54-02Z server /data
+            quay.io/minio/minio:RELEASE.2025-07-23T15-54-02Z server /data
           for attempt in $(seq 1 30); do
             if curl --fail --silent http://127.0.0.1:9000/minio/health/live >/dev/null; then
               exit 0

--- a/backend/src/platform/jobs/durableJobRuntime.ts
+++ b/backend/src/platform/jobs/durableJobRuntime.ts
@@ -181,5 +181,6 @@ export const closeDurableJobRuntime =
   async (): Promise<EmbeddedDurableJobWorkerStopResult> => {
     const current = runtime;
     runtime = undefined;
-    return current?.stop() ?? { activeAtStop: 0, abandoned: 0, failed: 0 };
+    if (current) return current.stop();
+    return { activeAtStop: 0, abandoned: 0, failed: 0 };
   };

--- a/backend/src/platform/storage/s3EncryptedBlobStore.ts
+++ b/backend/src/platform/storage/s3EncryptedBlobStore.ts
@@ -1340,7 +1340,7 @@ export class S3EncryptedBlobStore implements BlobStore {
       metadataCommitted = true;
       return descriptor;
     } catch (error) {
-      if (uploaded && !metadataCommitted) {
+      if (uploaded) {
         let outcome: 'absent' | { descriptor: BlobDescriptor };
         try {
           if (!storedMetadata) {

--- a/backend/src/routes/plugins.ts
+++ b/backend/src/routes/plugins.ts
@@ -903,7 +903,7 @@ router.get(
         return;
       }
 
-      const hasKey = pluginService.getApiKey(plugin, userId) !== null;
+      const hasKey = (await pluginService.getApiKey(plugin, userId)) !== null;
 
       res.json({
         success: true,

--- a/backend/src/services/calendarService.ts
+++ b/backend/src/services/calendarService.ts
@@ -321,7 +321,7 @@ class CalendarService {
     actor: AuthzActor,
     calendarId: string | undefined
   ): Promise<{ filename: string; content: string }> {
-    let name = 'calendar';
+    let name: string;
     let events: CalendarEvent[];
     const horizonFrom = 0;
     const horizonTo = Number.MAX_SAFE_INTEGER;

--- a/backend/src/services/chatService.ts
+++ b/backend/src/services/chatService.ts
@@ -131,6 +131,9 @@ class ChatService {
       markLost();
       throw leaseLostError();
     };
+    const scheduleRenewal = (): void => {
+      if (!closed && !leaseLost) renewalTimer = setTimeout(renew, 10_000);
+    };
     const renew = async (): Promise<void> => {
       if (closed) return;
       try {
@@ -138,7 +141,7 @@ class ChatService {
       } catch {
         markLost();
       }
-      if (!closed && !leaseLost) renewalTimer = setTimeout(renew, 10_000);
+      scheduleRenewal();
     };
     renewalTimer = setTimeout(renew, 10_000);
     try {

--- a/backend/src/services/documentService.ts
+++ b/backend/src/services/documentService.ts
@@ -182,8 +182,8 @@ const acquireDocumentResourceLease = async (
   const coordinator = getCoordinator();
   const ttlMs = resourceLeaseTtlMs();
   const deadline = Date.now() + waitMs;
-  let lease: CoordinationLease | null = null;
-  do {
+  let lease: CoordinationLease | null;
+  for (;;) {
     if (signal?.aborted) throw signal.reason;
     lease = await coordinator.acquireLease(
       `resource:${userId}:document:${documentId}`,
@@ -192,7 +192,7 @@ const acquireDocumentResourceLease = async (
     if (lease) break;
     if (Date.now() >= deadline) throw new DocumentResourceBusyError();
     await waitForLeaseRetry(25, signal);
-  } while (!lease);
+  }
 
   let closed = false;
   let lost = false;
@@ -1977,7 +1977,7 @@ export class DocumentService {
                 executionSpec
               )
             : undefined;
-        let localIndexReady =
+        const localIndexReady =
           localIndexProbe !== undefined &&
           (await platform.vectorStore.hasExactResourceIndex(localIndexProbe));
         const needsLazyPublication =
@@ -2022,7 +2022,6 @@ export class DocumentService {
                 () => lease!.assertHeld()
               );
             }
-            localIndexReady = true;
             searchableDocument = latest;
             documentChunks = latestChunks;
           } catch (error) {

--- a/backend/src/services/followUpService.ts
+++ b/backend/src/services/followUpService.ts
@@ -56,7 +56,7 @@ export function parseFollowUpSuggestions(raw: string): string[] {
     const cleaned = line
       .trim()
       .replace(/^```(?:\w+)?\s*|\s*```$/g, '')
-      .replace(/^[-*••]+\s*/, '')
+      .replace(/^[-*•]+\s*/, '')
       .replace(/^\d+[.)]\s*/, '')
       .replace(/^["'`]+|["'`]+$/g, '')
       .trim();

--- a/backend/src/services/galleryService.ts
+++ b/backend/src/services/galleryService.ts
@@ -152,6 +152,9 @@ class GalleryService {
       lost = true;
       throw new Error('The shared generated media write lease was lost');
     };
+    const scheduleRenewal = (): void => {
+      if (!closed && !lost) renewalTimer = setTimeout(renew, 10_000);
+    };
     const renew = async (): Promise<void> => {
       if (closed || lost) return;
       try {
@@ -159,7 +162,7 @@ class GalleryService {
       } catch {
         lost = true;
       }
-      if (!closed && !lost) renewalTimer = setTimeout(renew, 10_000);
+      scheduleRenewal();
     };
     renewalTimer = setTimeout(renew, 10_000);
     renewalTimer.unref?.();

--- a/backend/src/services/legacyCiphertextIntegrity.ts
+++ b/backend/src/services/legacyCiphertextIntegrity.ts
@@ -365,12 +365,12 @@ export const verifyLegacyCiphertextIntegrity = (
              FROM voice_profiles`
           )
           .get() as Aggregate;
-        selectedRecords = addBounded(
+        addBounded(
           selectedRecords,
           Number(aggregate.records),
           resolvedLimits.maxRecords
         );
-        selectedBytes = addBounded(
+        addBounded(
           selectedBytes,
           Number(aggregate.bytes),
           resolvedLimits.maxCiphertextBytes

--- a/backend/src/services/pluginCacheInvalidation.ts
+++ b/backend/src/services/pluginCacheInvalidation.ts
@@ -132,11 +132,12 @@ export const ensurePluginCacheInvalidationSubscription =
       );
       subscription = { coordinator, unsubscribe };
     })();
-    subscriptionInitialization = { coordinator, promise };
+    const initialization = { coordinator, promise };
+    subscriptionInitialization = initialization;
     try {
       await promise;
     } finally {
-      if (subscriptionInitialization?.promise === promise) {
+      if (subscriptionInitialization === initialization) {
         subscriptionInitialization = undefined;
       }
     }

--- a/backend/src/services/workRuntimeService.ts
+++ b/backend/src/services/workRuntimeService.ts
@@ -3342,6 +3342,9 @@ export class WorkRuntimeService {
           throw leaseLostError();
         };
         if (sharedLease) {
+          const scheduleRenewal = (): void => {
+            if (!closed && !lost) renewalTimer = setTimeout(renew, 20_000);
+          };
           const renew = async (): Promise<void> => {
             if (closed) return;
             try {
@@ -3356,7 +3359,7 @@ export class WorkRuntimeService {
             } catch {
               markLost();
             }
-            if (!closed && !lost) renewalTimer = setTimeout(renew, 20_000);
+            scheduleRenewal();
           };
           renewalTimer = setTimeout(renew, 20_000);
           renewalTimer.unref?.();

--- a/backend/src/services/workTaskService.ts
+++ b/backend/src/services/workTaskService.ts
@@ -192,6 +192,9 @@ export class WorkTaskService {
       markLost();
       throw leaseLostError();
     };
+    const scheduleRenewal = (): void => {
+      if (!closed && !leaseLost) renewalTimer = setTimeout(renew, 20_000);
+    };
     const renew = async (): Promise<void> => {
       if (closed) return;
       try {
@@ -199,7 +202,7 @@ export class WorkTaskService {
       } catch {
         markLost();
       }
-      if (!closed && !leaseLost) renewalTimer = setTimeout(renew, 20_000);
+      scheduleRenewal();
     };
     renewalTimer = setTimeout(renew, 20_000);
     try {

--- a/backend/src/utils/pluginStreamAdapter.ts
+++ b/backend/src/utils/pluginStreamAdapter.ts
@@ -414,7 +414,6 @@ export async function* streamOpenAIResponsesResponse(
     }
   >();
   let buffer = '';
-  let completed = false;
   let emittedAssistantText = '';
   let emittedReasoningBytes = 0;
   let outputItemOrder = 0;
@@ -855,7 +854,6 @@ export async function* streamOpenAIResponsesResponse(
                 );
               }
               const suffix = terminalContent.slice(emittedAssistantText.length);
-              emittedAssistantText = terminalContent;
               if (suffix) yield { type: 'content', content: suffix };
             }
           }
@@ -879,19 +877,16 @@ export async function* streamOpenAIResponsesResponse(
           )) {
             yield chunk;
           }
-          completed = true;
           return;
         }
       }
     }
 
-    if (!completed) {
-      for (const chunk of emitTerminalChunks(
-        undefined,
-        'incomplete:stream_ended'
-      )) {
-        yield chunk;
-      }
+    for (const chunk of emitTerminalChunks(
+      undefined,
+      'incomplete:stream_ended'
+    )) {
+      yield chunk;
     }
   } finally {
     reader.releaseLock();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -180,7 +180,6 @@ const main = () => {
     ...runtimeEnvironment(),
     SERVE_FRONTEND: 'true',
   };
-  const port = env.PORT || '8080';
 
   console.log(`
 ╭─────────────────────────────────────────────────╮

--- a/docker-compose.team.yml
+++ b/docker-compose.team.yml
@@ -75,7 +75,7 @@ services:
       - libre-team-redis:/data
 
   minio:
-    image: minio/minio:RELEASE.2025-07-23T15-54-02Z
+    image: quay.io/minio/minio:RELEASE.2025-07-23T15-54-02Z
     command: ['server', '/data', '--console-address', ':9001']
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:?set MINIO_ROOT_USER}
@@ -84,7 +84,7 @@ services:
       - libre-team-minio:/data
 
   minio-init:
-    image: minio/mc:RELEASE.2025-07-21T05-28-08Z
+    image: quay.io/minio/mc:RELEASE.2025-07-21T05-28-08Z
     depends_on:
       minio:
         condition: service_started

--- a/docs/08-PLUGIN_ARCHITECTURE.md
+++ b/docs/08-PLUGIN_ARCHITECTURE.md
@@ -88,6 +88,10 @@ silently reviving a dormant route.
 
 Credentials can come from environment variables or from user settings.
 
+Credential availability checks wait for the current user's credential lookup.
+They report whether an effective key exists without returning the key; a lookup
+failure returns an error instead of reporting that credentials are available.
+
 Environment examples:
 
 ```env

--- a/docs/45-PLATFORM_FOUNDATION.md
+++ b/docs/45-PLATFORM_FOUNDATION.md
@@ -91,6 +91,9 @@ active key plus the matching `legacy` entry.
 
 ### Run the bundled team profile
 
+The team profile and CI pull the pinned MinIO server and client images from
+`quay.io/minio`. Hosts that restrict registry access must permit `quay.io`.
+
 Start from the shipped fail-closed template. Keep the completed environment
 file outside the repository and restrict it to its operator:
 

--- a/examples/kyutai-tts-1.6b-server/server.py
+++ b/examples/kyutai-tts-1.6b-server/server.py
@@ -21,7 +21,6 @@ Features:
 import argparse
 import asyncio
 import io
-import os
 import re
 import sys
 import threading
@@ -34,7 +33,6 @@ import torch
 if sys.version_info >= (3, 12):
     torch._dynamo.config.suppress_errors = True
     # Monkey-patch torch.compile to be a no-op
-    _original_compile = torch.compile
     torch.compile = lambda func, *args, **kwargs: func
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -44,10 +42,10 @@ from pydantic import BaseModel
 # Kyutai TTS imports
 try:
     from moshi.models.loaders import CheckpointInfo
-    from moshi.models.tts import DEFAULT_DSM_TTS_REPO, DEFAULT_DSM_TTS_VOICE_REPO, TTSModel
+    from moshi.models.tts import DEFAULT_DSM_TTS_REPO, TTSModel
 except ImportError:
     print("Error: moshi package not installed. Install with: pip install moshi")
-    exit(1)
+    sys.exit(1)
 
 app = FastAPI(
     title="Kyutai TTS 1.6B OpenAI-Compatible API",

--- a/examples/kyutai-tts-server/server.py
+++ b/examples/kyutai-tts-server/server.py
@@ -23,7 +23,9 @@ import asyncio
 import io
 import os
 import re
+import sys
 import tempfile
+from contextlib import suppress
 from typing import Optional
 from urllib.parse import urlsplit
 
@@ -38,7 +40,7 @@ try:
     from pocket_tts import TTSModel
 except ImportError:
     print("Error: pocket-tts package not installed. Install with: pip install pocket-tts")
-    exit(1)
+    sys.exit(1)
 
 app = FastAPI(
     title="Kyutai TTS OpenAI-Compatible API",
@@ -442,10 +444,6 @@ async def create_streaming_speech(voice_state, text: str):
     async def audio_stream():
         loop = asyncio.get_event_loop()
 
-        def _stream():
-            for chunk in model.generate_audio_stream(voice_state, text, copy_state=True):
-                yield chunk
-
         # Run streaming in executor
         def _collect_chunks():
             chunks = []
@@ -497,9 +495,13 @@ async def create_voice_clone_speech(
     except Exception as e:
         if 'tmp_path' in locals():
             try:
-                os.unlink(tmp_path)
-            except:
-                pass
+                with suppress(FileNotFoundError):
+                    os.unlink(tmp_path)
+            except OSError as cleanup_error:
+                print(
+                    "Warning: Could not remove temporary reference audio: "
+                    f"{cleanup_error}"
+                )
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/examples/kyutai-tts-server/test_server_security.py
+++ b/examples/kyutai-tts-server/test_server_security.py
@@ -1,7 +1,15 @@
 import ast
+import asyncio
+import os
 import re
+import subprocess
+import sys
+import tempfile
 import unittest
+from contextlib import suppress
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 from urllib.parse import urlsplit
 
 
@@ -114,6 +122,177 @@ class KyutaiServerSecurityTests(unittest.TestCase):
             sanitize_text(f"before {stage_direction} after"),
             "before after",
         )
+
+
+class VoiceCloneCleanupTests(unittest.TestCase):
+    SERVER_PATHS = (
+        SERVER_PATH,
+        SERVER_PATH.parents[1] / "qwen-tts-server" / "server.py",
+    )
+
+    def load_endpoint(self, server_path, temporary_directory):
+        """Exercise both clone handlers without loading optional model packages."""
+        tree = ast.parse(server_path.read_text(encoding="utf-8"))
+        endpoint = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.AsyncFunctionDef)
+            and node.name == "create_voice_clone_speech"
+        )
+        endpoint.decorator_list = []
+
+        class HTTPException(Exception):
+            def __init__(self, status_code, detail):
+                super().__init__(detail)
+                self.status_code = status_code
+                self.detail = detail
+
+        def temporary_file(**kwargs):
+            return tempfile.NamedTemporaryFile(dir=temporary_directory, **kwargs)
+
+        namespace = {
+            "File": lambda default: default,
+            "Form": lambda default: default,
+            "HTTPException": HTTPException,
+            "UploadFile": object,
+            "Response": lambda **kwargs: SimpleNamespace(**kwargs),
+            "model": Mock(),
+            "model_type": "base-1.7b",
+            "os": SimpleNamespace(unlink=Mock(wraps=os.unlink)),
+            "tempfile": SimpleNamespace(NamedTemporaryFile=temporary_file),
+            "suppress": suppress,
+            "sanitize_text": lambda text: text,
+            "audio_to_bytes": Mock(return_value=b"audio"),
+            "print": Mock(),
+        }
+        namespace["model"].generate_voice_clone.return_value = (b"audio", 24000)
+        exec(
+            compile(
+                ast.Module(body=[endpoint], type_ignores=[]),
+                str(server_path),
+                "exec",
+            ),
+            namespace,
+        )
+        return namespace
+
+    def call_endpoint(self, namespace):
+        return asyncio.run(
+            namespace["create_voice_clone_speech"](
+                input="hello",
+                reference_audio=SimpleNamespace(
+                    read=AsyncMock(return_value=b"reference")
+                ),
+            )
+        )
+
+    def test_successful_clone_removes_reference_audio(self):
+        for server_path in self.SERVER_PATHS:
+            with (
+                self.subTest(server=server_path.parent.name),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                namespace = self.load_endpoint(server_path, directory)
+                response = self.call_endpoint(namespace)
+
+                self.assertEqual(response.content, b"audio")
+                self.assertEqual(list(Path(directory).iterdir()), [])
+                namespace["print"].assert_not_called()
+
+    def test_failed_generation_removes_reference_audio_and_preserves_error(self):
+        for server_path in self.SERVER_PATHS:
+            with (
+                self.subTest(server=server_path.parent.name),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                namespace = self.load_endpoint(server_path, directory)
+                namespace["model"].get_state_for_audio_prompt.side_effect = (
+                    RuntimeError("generation failed")
+                )
+                namespace["model"].generate_voice_clone.side_effect = RuntimeError(
+                    "generation failed"
+                )
+
+                with self.assertRaises(namespace["HTTPException"]) as raised:
+                    self.call_endpoint(namespace)
+
+                self.assertEqual(raised.exception.status_code, 500)
+                self.assertEqual(raised.exception.detail, "generation failed")
+                self.assertEqual(list(Path(directory).iterdir()), [])
+                namespace["print"].assert_not_called()
+
+    def test_cleanup_failure_is_reported_without_hiding_generation_error(self):
+        for server_path in self.SERVER_PATHS:
+            with (
+                self.subTest(server=server_path.parent.name),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                namespace = self.load_endpoint(server_path, directory)
+                namespace["model"].get_state_for_audio_prompt.side_effect = (
+                    RuntimeError("generation failed")
+                )
+                namespace["model"].generate_voice_clone.side_effect = RuntimeError(
+                    "generation failed"
+                )
+                namespace["os"].unlink.side_effect = PermissionError(
+                    "permission denied"
+                )
+
+                with self.assertRaises(namespace["HTTPException"]) as raised:
+                    self.call_endpoint(namespace)
+
+                self.assertEqual(raised.exception.detail, "generation failed")
+                namespace["print"].assert_called_once_with(
+                    "Warning: Could not remove temporary reference audio: "
+                    "permission denied"
+                )
+
+    def test_already_removed_reference_does_not_hide_encoding_error(self):
+        for server_path in self.SERVER_PATHS:
+            with (
+                self.subTest(server=server_path.parent.name),
+                tempfile.TemporaryDirectory() as directory,
+            ):
+                namespace = self.load_endpoint(server_path, directory)
+                namespace["audio_to_bytes"].side_effect = ValueError("encoding failed")
+
+                with self.assertRaises(namespace["HTTPException"]) as raised:
+                    self.call_endpoint(namespace)
+
+                self.assertEqual(raised.exception.detail, "encoding failed")
+                self.assertEqual(list(Path(directory).iterdir()), [])
+                namespace["print"].assert_not_called()
+
+
+class ModelDependencyExitTests(unittest.TestCase):
+    def test_missing_models_exit_cleanly_without_site_helpers(self):
+        server_paths = (
+            SERVER_PATH,
+            SERVER_PATH.parents[1] / "qwen-tts-server" / "server.py",
+            SERVER_PATH.parents[1] / "kyutai-tts-1.6b-server" / "server.py",
+        )
+        for server_path in server_paths:
+            with self.subTest(server=server_path.parent.name):
+                tree = ast.parse(server_path.read_text(encoding="utf-8"))
+                import_guard = next(
+                    node for node in tree.body if isinstance(node, ast.Try)
+                )
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-I",
+                        "-S",
+                        "-c",
+                        "import sys\n" + ast.unparse(import_guard),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("package not installed", result.stdout)
+                self.assertEqual(result.stderr, "")
 
 
 if __name__ == "__main__":

--- a/examples/qwen-tts-server/server.py
+++ b/examples/qwen-tts-server/server.py
@@ -24,7 +24,9 @@ import asyncio
 import io
 import os
 import re
+import sys
 import tempfile
+from contextlib import suppress
 from typing import Optional
 
 import torch
@@ -38,7 +40,7 @@ try:
     from qwen_tts import Qwen3TTSModel
 except ImportError:
     print("Error: qwen-tts package not installed. Install with: pip install qwen-tts")
-    exit(1)
+    sys.exit(1)
 
 app = FastAPI(
     title="Qwen3-TTS OpenAI-Compatible API",
@@ -596,9 +598,13 @@ async def create_voice_clone_speech(
     except Exception as e:
         if 'tmp_path' in locals():
             try:
-                os.unlink(tmp_path)
-            except:
-                pass
+                with suppress(FileNotFoundError):
+                    os.unlink(tmp_path)
+            except OSError as cleanup_error:
+                print(
+                    "Warning: Could not remove temporary reference audio: "
+                    f"{cleanup_error}"
+                )
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -540,7 +540,7 @@ const AppContent: React.FC = () => {
   return (
     <>
       {/* Show full layout only if system doesn't require auth or user is authenticated */}
-      {systemInfo && !systemInfo.requiresAuth ? (
+      {!systemInfo.requiresAuth ? (
         // No auth required - show full layout
         <ShellLayout
           sidebarOpen={sidebarOpen}

--- a/frontend/src/components/AppTabBar.tsx
+++ b/frontend/src/components/AppTabBar.tsx
@@ -360,7 +360,7 @@ export const AppTabBar: React.FC = () => {
     const currentIndex = items.indexOf(
       document.activeElement as HTMLButtonElement
     );
-    let nextIndex = currentIndex;
+    let nextIndex: number;
     if (event.key === 'ArrowDown') {
       nextIndex = (currentIndex + 1 + items.length) % items.length;
     } else if (event.key === 'ArrowUp') {

--- a/frontend/src/components/sidebar/SidebarSessions.tsx
+++ b/frontend/src/components/sidebar/SidebarSessions.tsx
@@ -452,35 +452,19 @@ export function SidebarSessions({
             </button>
           </div>
         ) : sessions.length === 0 ? (
-          <div
-            className={cn('text-center py-8', sidebarCompact ? 'px-1' : 'px-2')}
-          >
-            <div
-              className={cn(
-                'mx-auto mb-3 bg-white/70 dark:bg-dark-200 rounded-xl flex items-center justify-center ring-1 ring-black/[0.04] dark:ring-white/[0.05]',
-                sidebarCompact ? 'w-8 h-8' : 'w-12 h-12'
-              )}
-            >
-              <MessageSquare
-                className={cn(
-                  'text-gray-400 dark:text-gray-500',
-                  sidebarCompact ? 'h-4 w-4' : 'h-5 w-5'
-                )}
-              />
+          <div className='text-center py-8 px-2'>
+            <div className='mx-auto mb-3 bg-white/70 dark:bg-dark-200 rounded-xl flex items-center justify-center ring-1 ring-black/[0.04] dark:ring-white/[0.05] w-12 h-12'>
+              <MessageSquare className='text-gray-400 dark:text-gray-500 h-5 w-5' />
             </div>
-            {!sidebarCompact && (
-              <>
-                <p className='text-sm font-medium text-gray-600 dark:text-dark-600'>
-                  {t('chat.session.noChats')}
-                </p>
-                <p className='text-xs mt-1 text-gray-400 dark:text-dark-500'>
-                  {t('chat.session.createFirst')}
-                </p>
-              </>
-            )}
+            <p className='text-sm font-medium text-gray-600 dark:text-dark-600'>
+              {t('chat.session.noChats')}
+            </p>
+            <p className='text-xs mt-1 text-gray-400 dark:text-dark-500'>
+              {t('chat.session.createFirst')}
+            </p>
           </div>
         ) : (
-          <div className={cn('space-y-2', sidebarCompact && 'space-y-1')}>
+          <div className='space-y-2'>
             {sections.map(group => (
               <div key={group.key}>
                 {!sidebarCompact && group.folder && (

--- a/frontend/src/components/sidebar/SidebarWorkTasks.tsx
+++ b/frontend/src/components/sidebar/SidebarWorkTasks.tsx
@@ -596,37 +596,21 @@ export function SidebarWorkTasks({
             </span>
           </div>
         ) : tasks.length === 0 ? (
-          <div
-            className={cn('py-8 text-center', sidebarCompact ? 'px-1' : 'px-2')}
-          >
-            <div
-              className={cn(
-                'mx-auto mb-3 flex items-center justify-center rounded-xl bg-white/70 ring-1 ring-black/[0.04] dark:bg-dark-200 dark:ring-white/[0.05]',
-                sidebarCompact ? 'h-8 w-8' : 'h-12 w-12'
-              )}
-            >
-              <Briefcase
-                className={cn(
-                  'text-gray-400 dark:text-gray-500',
-                  sidebarCompact ? 'h-4 w-4' : 'h-5 w-5'
-                )}
-              />
+          <div className='py-8 text-center px-2'>
+            <div className='mx-auto mb-3 flex items-center justify-center rounded-xl bg-white/70 ring-1 ring-black/[0.04] dark:bg-dark-200 dark:ring-white/[0.05] h-12 w-12'>
+              <Briefcase className='text-gray-400 dark:text-gray-500 h-5 w-5' />
             </div>
-            {!sidebarCompact && (
-              <>
-                <p className='text-sm font-medium text-gray-600 dark:text-dark-600'>
-                  {t('work.tasks.emptyTitle', {
-                    defaultValue: 'No Work tasks yet',
-                  })}
-                </p>
-                <p className='mt-1 text-xs text-gray-400 dark:text-dark-500'>
-                  {t('work.tasks.empty', {
-                    defaultValue:
-                      'Your Work tasks will appear here after you send the first message.',
-                  })}
-                </p>
-              </>
-            )}
+            <p className='text-sm font-medium text-gray-600 dark:text-dark-600'>
+              {t('work.tasks.emptyTitle', {
+                defaultValue: 'No Work tasks yet',
+              })}
+            </p>
+            <p className='mt-1 text-xs text-gray-400 dark:text-dark-500'>
+              {t('work.tasks.empty', {
+                defaultValue:
+                  'Your Work tasks will appear here after you send the first message.',
+              })}
+            </p>
           </div>
         ) : (
           <div data-testid='sidebar-work-task-list' className='space-y-0.5'>

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1021,10 +1021,6 @@ export const useChat = (sessionId: string) => {
             assistantMessageId, // Send the message ID to backend
             isPrivate: isPrivateSession, // Private sessions don't persist to DB
             ...(webSearch === true ? { webSearch: true } : {}),
-            ...(tools === true && !isPrivateSession ? { tools: true } : {}),
-            ...(tools === true && !isPrivateSession && toolSelection
-              ? { toolSelection }
-              : {}),
             ...(isPrivateSession
               ? {
                   model: session?.model,

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -589,11 +589,7 @@ export const ChatPage: React.FC = () => {
             navigate('/', { replace: true });
           }
         }
-      } else if (
-        !sessionId &&
-        sessions.length > 0 &&
-        location.pathname === '/'
-      ) {
+      } else if (sessions.length > 0 && location.pathname === '/') {
         // No sessionId in URL but we have sessions, redirect to the most recent session
         // Only redirect from root path (/), not from /chat (which should show welcome screen)
         navigate(`/c/${sessions[0].id}`, { replace: true });
@@ -1259,7 +1255,7 @@ export const ChatPage: React.FC = () => {
               lastAssistantMessage={lastAssistantMessage}
             />
           )}
-          {currentSession && <ChatSourcesPanel session={currentSession} />}
+          <ChatSourcesPanel session={currentSession} />
           <ChatControlsPanel
             session={currentSession}
             open={controlsOpen}

--- a/scripts/add-headers.js
+++ b/scripts/add-headers.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
 
 const COPYRIGHT_HEADER = `/*
  * Libre WebUI

--- a/scripts/lib/work-test-platform.mjs
+++ b/scripts/lib/work-test-platform.mjs
@@ -24,7 +24,6 @@ export const initializeWorkTestPlatform = async repoRoot => {
   );
   let persistenceInitialized = false;
   let workInitialized = false;
-  let jobsInitialized = false;
   let coordinatorInitialized = false;
   try {
     await persistence.initializePersistence({
@@ -43,9 +42,7 @@ export const initializeWorkTestPlatform = async repoRoot => {
       handlers: new Map(),
       env: process.env,
     });
-    jobsInitialized = true;
   } catch (error) {
-    if (jobsInitialized) await jobs.closeDurableJobRuntime();
     if (coordinatorInitialized) await coordination.closeCoordinator();
     if (workInitialized) work.resetWorkPersistenceForTests();
     if (persistenceInitialized) await persistence.closePersistence();

--- a/scripts/test-chat-rest-responses.mjs
+++ b/scripts/test-chat-rest-responses.mjs
@@ -833,7 +833,7 @@ test('one enormous delta is split across events instead of failing', async () =>
     yield { type: 'done' };
   };
 
-  const queued = await chatService.queueDurableGeneration({
+  await chatService.queueDurableGeneration({
     sessionId: session.id,
     userId: 'chat-rest-user',
     userMessageId: 'user-oversized-single-delta',
@@ -890,7 +890,7 @@ test('a reply larger than the durable event ceiling still completes once', async
     yield { type: 'done' };
   };
 
-  const queued = await chatService.queueDurableGeneration({
+  await chatService.queueDurableGeneration({
     sessionId: session.id,
     userId: 'chat-rest-user',
     userMessageId: 'user-oversized-completion',
@@ -948,7 +948,7 @@ test('a provider that reports usage produces real token statistics', async () =>
     yield { type: 'done' };
   };
 
-  const queued = await chatService.queueDurableGeneration({
+  await chatService.queueDurableGeneration({
     sessionId: session.id,
     userId: 'chat-rest-user',
     userMessageId: 'user-plugin-usage-statistics',

--- a/scripts/test-docker-layout.mjs
+++ b/scripts/test-docker-layout.mjs
@@ -52,6 +52,10 @@ const teamPlatformTest = fs.readFileSync(
   path.join(repoRoot, 'scripts', 'test-team-platform.mjs'),
   'utf8'
 );
+const teamBackupTest = fs.readFileSync(
+  path.join(repoRoot, 'scripts', 'test-team-backup.mjs'),
+  'utf8'
+);
 const composeFiles = [
   'docker-compose.yml',
   'docker-compose.gpu.yml',
@@ -562,21 +566,22 @@ test('team Work overlay gives only app and worker the filtered Docker endpoint',
   );
 });
 
-test('real-service CI uses the exact shipped team dependency image tags', () => {
+test('real-service CI uses the exact shipped team dependency image references', () => {
   const composePostgres = teamCompose.match(
     /^  postgres:\n    image: (\S+)$/m
   )?.[1];
   const composeRedis = teamCompose.match(/^  redis:\n    image: (\S+)$/m)?.[1];
   const composeMinio = teamCompose.match(/^  minio:\n    image: (\S+)$/m)?.[1];
+  const composeMinioClient = teamCompose.match(
+    /^  minio-init:\n    image: (\S+)$/m
+  )?.[1];
   const ciPostgres = formatWorkflow.match(
     /^      postgres:\n        image: (\S+)$/m
   )?.[1];
   const ciRedis = formatWorkflow.match(
     /^      redis:\n        image: (\S+)$/m
   )?.[1];
-  const ciMinio = formatWorkflow.match(
-    /^\s+minio\/(?:minio):([^\s]+) server \/data$/m
-  )?.[1];
+  const ciMinio = formatWorkflow.match(/^\s+(\S+) server \/data$/m)?.[1];
   const releasePreflight = releaseWorkflow.slice(
     releaseWorkflow.indexOf('  release-preflight:'),
     releaseWorkflow.indexOf('  create-release:')
@@ -587,18 +592,27 @@ test('real-service CI uses the exact shipped team dependency image tags', () => 
   const releaseRedis = releasePreflight.match(
     /^      redis:\n        image: (\S+)$/m
   )?.[1];
-  const releaseMinio = releasePreflight.match(
-    /^\s+minio\/(?:minio):([^\s]+) server \/data$/m
+  const releaseMinio = releasePreflight.match(/^\s+(\S+) server \/data$/m)?.[1];
+  const teamMinioClient = teamPlatformTest.match(
+    /^\s+'(quay\.io\/minio\/mc:[^']+)',$/m
+  )?.[1];
+  const backupMinio = teamBackupTest.match(
+    /const MINIO_IMAGE =\s*'([^']+)';/
   )?.[1];
 
   assert.equal(ciPostgres, composePostgres);
   assert.equal(ciRedis, composeRedis);
-  assert.equal(ciMinio ? `minio/minio:${ciMinio}` : undefined, composeMinio);
+  assert.match(composeMinio, /^quay\.io\/minio\/minio:RELEASE\.[\w-]+$/);
+  assert.equal(ciMinio, composeMinio);
   assert.equal(releasePostgres, composePostgres);
   assert.equal(releaseRedis, composeRedis);
-  assert.equal(
-    releaseMinio ? `minio/minio:${releaseMinio}` : undefined,
-    composeMinio
+  assert.equal(releaseMinio, composeMinio);
+  assert.match(composeMinioClient, /^quay\.io\/minio\/mc:RELEASE\.[\w-]+$/);
+  assert.equal(teamMinioClient, composeMinioClient);
+  assert.match(
+    backupMinio,
+    /^quay\.io\/minio\/minio@sha256:[a-f0-9]{64}$/,
+    'backup fixture must use a digest-pinned MinIO image from Quay'
   );
   const testStorageKey = '91'.repeat(32);
   for (const workflow of [formatWorkflow, releasePreflight]) {

--- a/scripts/test-plugin-endpoint-routing.mjs
+++ b/scripts/test-plugin-endpoint-routing.mjs
@@ -725,6 +725,61 @@ test('pre-upgrade writable definitions stay quarantined across every execution p
   }
 });
 
+test('plugin credential checks await lookup results and report lookup failures', async () => {
+  const app = express();
+  app.use('/api/plugins', authenticate, pluginRoutes);
+  const server = await listen(app);
+  const user = upsertTestUser('plugin-credential-check-user', 'user');
+  const headers = {
+    Authorization: `Bearer ${authService.generateToken(user)}`,
+  };
+  const url = `${server.baseUrl}/api/plugins/openai/credentials/check`;
+
+  try {
+    for (const key of [null, 'credential-check-secret']) {
+      await withPatchedProperties(
+        pluginService,
+        {
+          getApiKey: async (plugin, userId) => {
+            assert.equal(plugin.id, 'openai');
+            assert.equal(userId, user.id);
+            await new Promise(resolve => setImmediate(resolve));
+            return key;
+          },
+        },
+        async () => {
+          const response = await fetch(url, { headers });
+          assert.equal(response.status, 200);
+          assert.deepEqual(await response.json(), {
+            success: true,
+            data: key !== null,
+          });
+        }
+      );
+    }
+
+    await withPatchedProperties(
+      pluginService,
+      {
+        getApiKey: async () => {
+          await new Promise(resolve => setImmediate(resolve));
+          throw new Error('Credential lookup unavailable');
+        },
+      },
+      async () => {
+        const response = await fetch(url, { headers });
+        assert.equal(response.status, 500);
+        assert.deepEqual(await response.json(), {
+          success: false,
+          error: 'Credential lookup unavailable',
+        });
+      }
+    );
+  } finally {
+    await server.close();
+  }
+});
+
 test('plugin routes require authentication and preserve non-admin generation settings', async () => {
   const app = express();
   app.use(express.json());

--- a/scripts/test-team-backup.mjs
+++ b/scripts/test-team-backup.mjs
@@ -25,7 +25,7 @@ import {
 const POSTGRES_IMAGE =
   'pgvector/pgvector@sha256:a36250871de0833b8757561c72f2477ef1ddd1101afa4e617fb552e0de514c6b';
 const MINIO_IMAGE =
-  'minio/minio@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e';
+  'quay.io/minio/minio@sha256:a1ea29fa28355559ef137d71fc570e508a214ec84ff8083e39bc5428980b015e';
 const dockerGate = process.env.TEST_TEAM_PLATFORM === '1';
 
 const docker = (args, options = {}) =>

--- a/scripts/test-team-platform.mjs
+++ b/scripts/test-team-platform.mjs
@@ -106,7 +106,7 @@ test(
           `${project}_default`,
           '--env',
           'MC_HOST_local=http://libreteam:libre-team-minio-password@minio:9000',
-          'minio/mc:RELEASE.2025-07-21T05-28-08Z',
+          'quay.io/minio/mc:RELEASE.2025-07-21T05-28-08Z',
           'stat',
           `local/libre-blobs/${objectKey}`,
         ],

--- a/scripts/test-work-mcp.mjs
+++ b/scripts/test-work-mcp.mjs
@@ -263,7 +263,7 @@ test('connected tools reach network-enabled runs and stay off offline ones', asy
   // A network-enabled run offers the namespaced tools and a call round-trips
   // through the hardened gateway to the MCP server.
   providerScript.push(
-    (request, observer) => {
+    request => {
       const names = toolNames(request);
       assert.ok(names.includes('notes_mcp__echo_note'), names.join(','));
       assert.ok(names.includes('notes_mcp__write_note'));
@@ -272,7 +272,7 @@ test('connected tools reach network-enabled runs and stay off offline ones', asy
       assert.match(request.messages[0].content, /notes_mcp__echo_note/);
       return toolTurn('call-1', 'notes_mcp__echo_note', {
         text: 'from work',
-      })(request, observer);
+      })(request);
     },
     textTurn('Echoed.')
   );
@@ -389,14 +389,14 @@ test('servers missing a personal credential are filtered at offer time', async (
 
   await toolServers.setToolServerCredential(userId, secured.id, 'token-123');
   providerScript.push(
-    (request, observer) => {
+    request => {
       assert.ok(
         toolNames(request).includes('secured_mcp__echo_note'),
         'the credentialed server is offered'
       );
       return toolTurn('call-4', 'secured_mcp__echo_note', {
         text: 'secured',
-      })(request, observer);
+      })(request);
     },
     textTurn('Secured echo done.')
   );


### PR DESCRIPTION
The plugin credential check compared an unresolved Promise with `null`, so it could report a missing API key as present. Await the lookup and cover missing keys, saved keys, and lookup failures with an HTTP regression.

Address all 50 reported findings across the 11 CodeQL quality rules: remove redundant conditions, unused values and arguments, and a duplicate regex character; use reliable Python exits and report temporary-file cleanup failures. Preserve lease renewal guards, ciphertext bounds, and storage recovery behavior. Add speech-server startup and cleanup regressions and document credential checks.

Restore CI's MinIO fixture by pulling the public Quay images in both workflows, team Compose, and the backup and multi-replica test fixtures. Preserve every image version and the backup digest. Extend the image-parity regression to compare complete registry-qualified references and document the registry access requirement.

Validation for the code-quality fixes:

- Formatting, lint, both workspace type-checks, and build passed.
- Frontend unit tests: 238 passed. Work suite: 168 passed.
- Full package rerun: 1,415 passed, 8 skipped, 0 failed. Skips cover PostgreSQL/PGVector, Redis, team backup/S3, and an existing document collection-filter test. Two team-storage integration scripts also skipped because the test environment was not configured.
- Browser tests: 316 Chromium tests passed, with one optional benchmark skipped. Three WebKit tests initially could not launch; after installing the missing browser, all three passed on rerun.
- Focused credential, provider streaming, cache invalidation, recovery, CLI, MCP, chat, and Python regressions passed.
- The initial package attempt hit an overlapping build that removed generated output; the isolated full rerun passed.

Validation for the MinIO registry fix:

- Anonymous registry manifest checks and Docker pulls succeeded for the server, client, and existing backup digest.
- All three images executed and reported the expected versions.
- An isolated MinIO container passed health checks, matching-client bucket setup, bucket versioning, two S3 object writes, version listing, and object readback. The temporary container and its data were removed.
- Docker layout and workflow regressions: 25 passed, 0 failed or skipped. Formatting and diff checks passed.
- Full package, browser, and three-replica suites were not rerun locally for this registry-only follow-up; GitHub CI validates the updated PR.
